### PR TITLE
Fix lcc compiler compile error

### DIFF
--- a/Utils/lcc/makefile
+++ b/Utils/lcc/makefile
@@ -3,7 +3,7 @@ A=.a
 O=.o
 E=
 CC=cc
-CFLAGS=-g
+CFLAGS=-g -std=c11
 LDFLAGS=-g
 LD=$(CC)
 AR=ar ruv

--- a/Utils/lcc/makefile
+++ b/Utils/lcc/makefile
@@ -179,25 +179,25 @@ gttest: $Techo \
 $Tgigatron.rom: gt1/none/tst/ROMv3.rom; cp $< $@
 $Tharness$O: gt1/none/tst/harness.c; $(CC) $(CFLAGS) -c -o $@ $^
 
-$Techo$O: gt1/none/tst/echo.c; $(CC) $(CFlAGS) -c -o $@ $^
+$Techo$O: gt1/none/tst/echo.c; $(CC) $(CFLAGS) -c -o $@ $^
 $Techo.gt1: gt1/none/tst/echo.c all; LCCDIR=$(BUILDDIR) $(BUILDDIR)/lcc -DTEST $< -o $Techo.gt1
 $Techo: $Techo.gt1 $Tgigatron.rom $Techo$O $(GTHARNESS)
 	$(LD) $(LDFLAGS) -o $@ $Techo$O $(GTHARNESS)
 	cd $T && ./echo echo.log
 
-$Temu$O: gt1/none/tst/emu.c; $(CC) $(CFlAGS) -c -o $@ $^
+$Temu$O: gt1/none/tst/emu.c; $(CC) $(CFLAGS) -c -o $@ $^
 $Temu.gt1: gt1/none/tst/emu.c all; LCCDIR=$(BUILDDIR) $(BUILDDIR)/lcc -DTEST $< -o $Temu.gt1
 $Temu: $Temu.gt1 $Tgigatron.rom $Temu$O $(GTHARNESS)
 	$(LD) $(LDFLAGS) -o $@ $Temu$O $(GTHARNESS)
 	cd $T && ./emu emu.log
 
-$Tsmath$O: gt1/none/tst/smath.c; $(CC) $(CFlAGS) -c -o $@ $^
+$Tsmath$O: gt1/none/tst/smath.c; $(CC) $(CFLAGS) -c -o $@ $^
 $Tsmath.gt1: gt1/none/tst/smath.c all; LCCDIR=$(BUILDDIR) $(BUILDDIR)/lcc -DTEST $< -o $Tsmath.gt1
 $Tsmath: $Tsmath.gt1 $Tgigatron.rom $Tsmath$O $(GTHARNESS)
 	$(LD) $(LDFLAGS) -o $@ $Tsmath$O $(GTHARNESS)
 	cd $T && ./smath smath.log
 
-$Tumath$O: gt1/none/tst/umath.c; $(CC) $(CFlAGS) -c -o $@ $^
+$Tumath$O: gt1/none/tst/umath.c; $(CC) $(CFLAGS) -c -o $@ $^
 $Tumath.gt1: gt1/none/tst/umath.c all; LCCDIR=$(BUILDDIR) $(BUILDDIR)/lcc -DTEST $< -o $Tumath.gt1
 $Tumath: $Tumath.gt1 $Tgigatron.rom $Tumath$O $(GTHARNESS)
 	$(LD) $(LDFLAGS) -o $@ $Tumath$O $(GTHARNESS)


### PR DESCRIPTION
On a clean machine, I came to the discovery that `make lcc` failed; it gave the following set of (similar) errors:
`./build/gt1.c:3840:2: error: ‘for’ loop initial declarations are only allowed in C99 mode`

After research, I came to the conclusion that either **Utils/lcc/src/gt1.md** violates the standard on six occasions, or the makefile needed `CFLAGS=-std=c11` , similar as the root Makefile.
Also, I noted that the variable was referenced incorrectly.

This pull request should fix the compiler error (tested on **RHEL 7.6**, **GNU Make 3.82** and **gcc 4.8.5**
