### PR TITLE
Port several files to Python3

### DIFF
--- a/Apps/Loader/SYS_Loader.py
+++ b/Apps/Loader/SYS_Loader.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 #-----------------------------------------------------------------------
 #
@@ -37,13 +44,13 @@ adda(1)                         #25
 st([sysArgs+0])                 #26
 ld(hi('REENTER'),Y)             #27
 jmp(Y,'REENTER')                #28
-ld(-32/2)                       #29
+ld(-32//2)                      #29
 # Restart the instruction in the next timeslice
 label('.sysNbi#19')
 ld([vPC])                       #19
 suba(2)                         #20
 st([vPC])                       #21
-ld(-28/2)                       #22
+ld(-28//2)                      #22
 ld(hi('REENTER'),Y)             #23
 jmp(Y,'REENTER')                #24
 nop()                           #25
@@ -106,7 +113,7 @@ st([channelMask])               #57
 nop()                           #58
 ld(hi('REENTER'),Y)             #59
 jmp(Y,'REENTER')                #60
-ld(-64/2)                       #61
+ld(-64//2)                      #61
 # Invalid checksum
 label('.sysPi#19')
 wait(25-19);                    C('Invalid checksum')#19 Reset checksum
@@ -116,7 +123,7 @@ ld(ord('g'));                   C('Unknown command')#25 Reset checksum
 st([sysArgs+2])                 #26
 ld(hi('REENTER'),Y)             #27
 jmp(Y,'REENTER')                #28
-ld(-32/2)                       #29
+ld(-32//2)                      #29
 # Loading data
 label('.sysPi#37')
 ld([sysArgs+0]);                C('Loading data')#37 Continue checksum
@@ -125,7 +132,7 @@ ld([Y,X])                       #39
 st([sysArgs+2])                 #40
 ld(hi('REENTER'),Y)             #41
 jmp(Y,'REENTER')                #42
-ld(-46/2)                       #43
+ld(-46//2)                      #43
 
 #-----------------------------------------------------------------------
 # Extension SYS_LoaderPayloadCopy_34
@@ -155,7 +162,7 @@ ld(hi('REENTER'),Y)             #18,29
 wait(30-19)                     #19
 label('.sysCc#30')
 jmp(Y,'REENTER')                #30
-ld(-34/2)                       #31
+ld(-34//2)                      #31
 
 #-----------------------------------------------------------------------
 #

--- a/Apps/Racer/SYS_Racer_v1.py
+++ b/Apps/Racer/SYS_Racer_v1.py
@@ -1,9 +1,15 @@
-
+# -*- coding: utf-8 -*-
 #-----------------------------------------------------------------------
 #
 #       Racer-specific SYS extensions
 #
 #-----------------------------------------------------------------------
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 from asm import *
 
@@ -52,7 +58,7 @@ st([vPC])                       #34
 label('.sysRacer1')
 ld(hi('REENTER'),Y)             #35
 jmp(Y,'REENTER')                #36
-ld(-40/2)                       #37
+ld(-40//2)                      #37
 
 #-----------------------------------------------------------------------
 #       SYS_RacerUpdateVideoY_40
@@ -91,7 +97,7 @@ adda(1)                         #33
 st([sysArgs+2])                 #34
 ld(hi('REENTER'),Y)             #35
 jmp(Y,'REENTER')                #36
-ld(-40/2)                       #37
+ld(-40//2)                      #37
 
 #-----------------------------------------------------------------------
 #

--- a/Core/dev.py
+++ b/Core/dev.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 #-----------------------------------------------------------------------
 #
 #  Core video, sound and interpreter loop for Gigatron TTL microcomputer
@@ -372,15 +379,15 @@ screenMemory = 0x0800   # Default start of screen memory: 0x0800 to 0x7fff
 #  Application definitions
 #-----------------------------------------------------------------------
 
-maxTicks = 28/2                 # Duration of vCPU's slowest virtual opcode (ticks)
-minTicks = 14/2                 # vcPU's fastest instruction
-v6502_maxTicks = 38/2           # Max duration of v6502 processing phase (ticks)
+maxTicks = 28//2                 # Duration of vCPU's slowest virtual opcode (ticks)
+minTicks = 14//2                 # vcPU's fastest instruction
+v6502_maxTicks = 38//2           # Max duration of v6502 processing phase (ticks)
 
 runVcpu_overhead = 5            # Caller overhead (cycles)
 vCPU_overhead = 9               # Callee overhead of jumping in and out (cycles)
 v6502_overhead = 11             # Callee overhead for v6502 (cycles)
 
-v6502_adjust = (v6502_maxTicks - maxTicks) + (v6502_overhead - vCPU_overhead)/2
+v6502_adjust = (v6502_maxTicks - maxTicks) + (v6502_overhead - vCPU_overhead)//2
 assert v6502_adjust >= 0        # v6502's overhead is a bit more than vCPU
 
 def runVcpu(n, ref=None, returnTo=None):
@@ -419,7 +426,7 @@ def runVcpu(n, ref=None, returnTo=None):
     n -= 1
   assert n % 2 == 0
 
-  print 'runVcpu at $%04x net cycles %3s info %s' % (pc(), n, ref)
+  print('runVcpu at $%04x net cycles %3s info %s' % (pc(), n, ref))
 
   if returnTo != 0x100:
     if returnTo is None:
@@ -428,7 +435,7 @@ def runVcpu(n, ref=None, returnTo=None):
     comment = C(comment)
     st([vReturn])               #1
 
-  n /= 2
+  n //= 2
   n -= maxTicks                 # First instruction always runs
   assert n < 128
   assert n >= v6502_adjust
@@ -601,7 +608,7 @@ st('SYS_Reset_88',    [Y,Xpp]); C('SYS_Reset_88')
 st('STW',             [Y,Xpp]); C('STW')
 st(sysFn,             [Y,Xpp]); C('sysFn')
 st('SYS',             [Y,Xpp]); C('SYS -> SYS_Reset_88 -> SYS_Exec_88')
-st(256-88/2+maxTicks, [Y,Xpp]); C('270-88/2')
+st(256-88//2+maxTicks, [Y,Xpp]); C('270-88/2')
 st(0,                 [Y,Xpp]);
 st(0,                 [Y,Xpp]);
 st(0,                 [Y,Xpp]);
@@ -678,7 +685,7 @@ nop()                           #38
 # Return to interpreter
 ld(hi('REENTER'),Y)             #39
 jmp(Y,'REENTER')                #40
-ld(-44/2)                       #41
+ld(-44//2)                     #41
 
 #-----------------------------------------------------------------------
 # Placeholders for future SYS functions. This works as a kind of jump
@@ -699,65 +706,68 @@ ld(-44/2)                       #41
 
 align(0x80, 0x80)
 
+assert pc() >> 8 == 0, "forth.next3_rom_return must not push the SYS placeholders off page zero"
+
+
 ld(hi('REENTER'),Y)             #15 slot 0x80
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0x83
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0x86
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0x89
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0x8c
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0x8f
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0x92
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0x95
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0x98
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0x9b
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0x9e
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xa1
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xa4
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xa7
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xaa
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 #-----------------------------------------------------------------------
 # Extension SYS_Exec_88: Load code from ROM into memory and execute it
@@ -787,91 +797,91 @@ ld(0)                           #17 Address of loader on zero page
 
 ld(hi('REENTER'),Y)             #15 slot 0xb0
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xb3
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xb6
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xb9
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xbc
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xbf
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xc2
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xc5
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xc8
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xcb
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xce
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xd1
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xd4
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xd7
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xda
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xdd
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xe0
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xe3
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xe6
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xe9
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xec
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 ld(hi('REENTER'),Y)             #15 slot 0xef
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 fillers(until=symbol('SYS_Out_22') & 255)
 
@@ -889,7 +899,7 @@ ld([sysArgs+0],OUT)             #15
 nop()                           #16
 ld(hi('REENTER'),Y)             #17
 jmp(Y,'REENTER')                #18
-ld(-22/2)                       #19
+ld(-22//2)                      #19
 
 #-----------------------------------------------------------------------
 # Extension SYS_In_24
@@ -907,7 +917,7 @@ st([vAC+1])                     #17
 nop()                           #18
 ld(hi('REENTER'),Y)             #19
 jmp(Y,'REENTER')                #20
-ld(-24/2)                       #21
+ld(-24//2)                      #21
 
 assert pc()&255 == 0
 
@@ -1027,7 +1037,7 @@ if soundDiscontinuity == 2:
   C('Sound continuity')
   extra += 1
 if soundDiscontinuity > 2:
-  print 'Warning: sound discontinuity not suppressed'
+  print('Warning: sound discontinuity not suppressed')
 
 runVcpu(186-72-extra, '---D line 0')#72 Application cycles (scan line 0)
 
@@ -1465,7 +1475,7 @@ st([vAC+1])                     #13
 ld([vPC])                       #14 Advance vPC one more
 adda(1)                         #15
 st([vPC])                       #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 bra('NEXT')                     #18
 #dummy()                        #19 Overlap
 #
@@ -1494,7 +1504,7 @@ ld([vTmp],X)                    #15
 ld([X])                         #16
 st([vAC+1])                     #17
 bra('NEXT')                     #18
-ld(-20/2)                       #19
+ld(-20//2)                      #19
 
 # Instruction STW: Store word in zero page ([D],[D+1]=vAC&255,vAC>>8), 20 cycles
 label('STW')
@@ -1507,7 +1517,7 @@ ld([vTmp],X)                    #15
 ld([vAC+1])                     #16
 st([X])                         #17
 bra('NEXT')                     #18
-ld(-20/2)                       #19
+ld(-20//2)                      #19
 
 # Instruction BCC: Test AC sign and branch conditionally, 28 cycles
 label('BCC')
@@ -1548,7 +1558,7 @@ ld([Y,X])                       #24
 label('.bcc#25')
 st([vPC])                       #25
 bra('NEXT')                     #26
-ld(-28/2)                       #27
+ld(-28//2)                      #27
 
 # Conditional GT: Branch if positive (if(vACL>0)vPCL=D)
 label('GT')
@@ -1580,7 +1590,7 @@ st([vAC])                       #10
 ld(0)                           #11
 st([vAC+1])                     #12
 bra('NEXTY')                    #13
-ld(-16/2)                       #14
+ld(-16//2)                      #14
 
 # Instruction ST: Store byte in zero page ([D]=vAC&255), 16 cycles
 label('ST')
@@ -1588,7 +1598,7 @@ ld(AC,X)                        #10,15
 ld([vAC])                       #11
 st([X])                         #12
 bra('NEXTY')                    #13
-ld(-16/2)                       #14
+ld(-16//2)                      #14
 
 # Instruction POP: Pop address from stack (vLR,vSP==[vSP]+256*[vSP+1],vSP+2), 26 cycles
 label('POP')
@@ -1607,7 +1617,7 @@ ld([vPC])                       #20
 suba(1)                         #21
 st([vPC])                       #22
 bra('NEXTY')                    #23
-ld(-26/2)                       #24
+ld(-26//2)                      #24
 
 # Conditional NE: Branch if not zero (if(vACL!=0)vPCL=D)
 label('NE')
@@ -1651,20 +1661,20 @@ label('ORI')
 ora([vAC])                      #10
 st([vAC])                       #11
 bra('NEXT')                     #12
-ld(-14/2)                       #13
+ld(-14//2)                      #13
 
 # Instruction XORI: Logical-XOR with small constant (vAC^=D), 14 cycles
 label('XORI')
 xora([vAC])                     #10
 st([vAC])                       #11
 bra('NEXT')                     #12
-ld(-14/2)                       #13
+ld(-14//2)                      #13
 
 # Instruction BRA: Branch unconditionally (vPC=(vPC&0xff00)+D), 14 cycles
 label('BRA')
 st([vPC])                       #10
 bra('NEXTY')                    #11
-ld(-14/2)                       #12
+ld(-14//2)                      #12
 
 # Instruction INC: Increment zero page byte ([D]++), 20 cycles
 label('INC')
@@ -1705,7 +1715,7 @@ ld([vTmp],X)                    #23
 adda([X])                       #24
 st([vAC+1])                     #25 Store high result
 bra('NEXT')                     #26
-ld(-28/2)                       #27
+ld(-28//2)                      #27
 
 # Instruction PEEK: Read byte from memory (vAC=[vAC]), 26 cycles
 label('PEEK')
@@ -1734,7 +1744,7 @@ ld([vPC]);                      C('Retry until sufficient time')#13,12
 suba(2)                         #14
 st([vPC])                       #15
 bra('REENTER')                  #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 label('SYS')
 adda([vTicks])                  #10
 blt('.sys#13');                 #11
@@ -1766,7 +1776,7 @@ ld([vTmp],X)                    #22
 suba([X])                       #23
 st([vAC+1])                     #24
 label('REENTER_28')
-ld(-28/2)                       #25
+ld(-28//2)                      #25
 label('REENTER')
 bra('NEXT');                    C('Return from SYS calls')#26
 ld([vPC+1],Y)                   #27
@@ -1794,14 +1804,14 @@ adda(1,X)                       #21
 ld([X])                         #22
 st([vPC+1],Y)                   #23
 bra('NEXT')                     #24
-ld(-26/2)                       #25
+ld(-26//2)                      #25
 
 # Instruction ALLOC: Create or destroy stack frame (vSP+=D), 14 cycles
 label('ALLOC')
 adda([vSP])                     #10
 st([vSP])                       #11
 bra('NEXT')                     #12
-ld(-14/2)                       #13
+ld(-14//2)                      #13
 
 # The instructions below are all implemented in the second code page. Jumping
 # back and forth makes each 6 cycles slower, but it also saves space in the
@@ -1899,7 +1909,7 @@ ld([vLR+1])                     #13
 st([vPC+1])                     #14
 ld(hi('REENTER'),Y)             #15
 jmp(Y,'REENTER')                #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 
 # DEF implementation
 label('def#13')
@@ -1912,7 +1922,7 @@ ld([vTmp])                      #18
 st([vPC])                       #19
 ld(hi('NEXTY'),Y)               #20
 jmp(Y,'NEXTY')                  #21
-ld(-24/2)                       #22
+ld(-24//2)                      #22
 
 # Clear vACH (continuation of ANDI and LD instructions)
 label('andi#13')
@@ -1924,7 +1934,7 @@ ld(0)                           #15 Clear high byte
 st([vAC+1])                     #16
 ld(hi('REENTER'),Y)             #17
 jmp(Y,'REENTER')                #18
-ld(-22/2)                       #19
+ld(-22//2)                      #19
 
 # ADDI implementation
 label('addi')
@@ -1992,7 +2002,7 @@ ld([vAC])                       #19
 st([X])                         #20
 ld(hi('REENTER'),Y)             #21
 jmp(Y,'REENTER')                #22
-ld(-26/2)                       #23
+ld(-26//2)                      #23
 
 # LDLW implementation
 label('ldlw')
@@ -2006,7 +2016,7 @@ ld([X])                         #19
 st([vAC])                       #20
 ld(hi('REENTER'),Y)             #21
 jmp(Y,'REENTER')                #22
-ld(-26/2)                       #23
+ld(-26//2)                      #23
 
 # POKE implementation
 label('poke')
@@ -2020,7 +2030,7 @@ ld([vAC])                       #19
 st([Y,X])                       #20
 ld(hi('REENTER'),Y)             #21
 jmp(Y,'REENTER')                #22
-ld(-26/2)                       #23
+ld(-26//2)                      #23
 
 # PEEK implementation
 label('peek')
@@ -2035,7 +2045,7 @@ ld(0)                           #19
 st([vAC+1])                     #20
 ld(hi('REENTER'),Y)             #21
 jmp(Y,'REENTER')                #22
-ld(-26/2)                       #23
+ld(-26//2)                      #23
 
 # DOKE implementation
 label('doke')
@@ -2051,7 +2061,7 @@ ld([vAC+1])                     #21
 st([Y,X])                       #22 Incompatible with REENTER_28
 ld(hi('REENTER'),Y)             #23
 jmp(Y,'REENTER')                #24
-ld(-28/2)                       #25
+ld(-28//2)                      #25
 
 # DEEK implementation
 label('deek')
@@ -2110,7 +2120,7 @@ xora([vAC])                     #19
 st([vAC])                       #20
 ld(hi('REENTER'),Y)             #21
 jmp(Y,'REENTER')                #22
-ld(-26/2)                       #23
+ld(-26//2)                      #23
 
 #-----------------------------------------------------------------------
 #
@@ -2160,7 +2170,7 @@ st([entropy+1])                 #27
 st([vAC+1])                     #28
 ld(hi('REENTER'),Y)             #29
 jmp(Y,'REENTER')                #30
-ld(-34/2)                       #31
+ld(-34//2)                      #31
 
 label('SYS_LSRW7_30')
 ld([vAC])                       #15
@@ -2175,7 +2185,7 @@ ld([X])                         #23
 st([vAC+1])                     #24
 ld(hi('REENTER'),Y)             #25
 jmp(Y,'REENTER')                #26
-ld(-30/2)                       #27
+ld(-30//2)                      #27
 
 label('SYS_LSRW8_24')
 ld([vAC+1])                     #15
@@ -2184,7 +2194,7 @@ ld(0)                           #17
 st([vAC+1])                     #18
 ld(hi('REENTER'),Y)             #19
 jmp(Y,'REENTER')                #20
-ld(-24/2)                       #21
+ld(-24//2)                      #21
 
 label('SYS_LSLW8_24')
 ld([vAC])                       #15
@@ -2193,7 +2203,7 @@ ld(0)                           #17
 st([vAC])                       #18
 ld(hi('REENTER'),Y)             #19
 jmp(Y,'REENTER')                #20
-ld(-24/2)                       #21
+ld(-24//2)                      #21
 
 #-----------------------------------------------------------------------
 # Extension SYS_Draw4_30
@@ -2218,7 +2228,7 @@ ld([sysArgs+3])                 #23
 st([Y,Xpp])                     #24
 ld(hi('REENTER'),Y)             #25
 jmp(Y,'REENTER')                #26
-ld(-30/2)                       #27
+ld(-30//2)                      #27
 
 #-----------------------------------------------------------------------
 # Extension SYS_VDrawBits_134:
@@ -2255,7 +2265,7 @@ bne('.vdb0')                    #29+i*14
 adda(8)                         #30+i*14
 ld(hi('REENTER'),Y)             #129
 jmp(Y,'REENTER')                #130
-ld(-134/2)                      #131
+ld(-134//2)                     #131
 
 #-----------------------------------------------------------------------
 
@@ -2265,7 +2275,7 @@ adda([X])                       #14
 st([X])                         #15
 ld(hi('NEXTY'),Y)               #16
 jmp(Y,'NEXTY')                  #17
-ld(-20/2)                       #18
+ld(-20//2)                      #18
 
 #-----------------------------------------------------------------------
 #
@@ -2333,7 +2343,7 @@ label('.sysLsrw1b')
 st([vAC+1])                     #42
 ld(hi('REENTER'),Y)             #43
 jmp(Y,'REENTER')                #44
-ld(-48/2)                       #45
+ld(-48//2)                      #45
 
 label('SYS_LSRW2_52')
 ld(hi('shiftTable'),Y);         C('Logical shift right 2 bit (X >> 2)')#15
@@ -2366,7 +2376,7 @@ label('.sysLsrw2b')
 st([vAC+1])                     #46
 ld(hi('REENTER'),Y)             #47
 jmp(Y,'REENTER')                #48
-ld(-52/2)                       #49
+ld(-52//2)                      #49
 
 label('SYS_LSRW3_52')
 ld(hi('shiftTable'),Y);         C('Logical shift right 3 bit (X >> 3)')#15
@@ -2396,7 +2406,7 @@ jmp(Y,AC)                       #40
 bra(255);                       C('bra $%04x' % (shiftTable+255))#41
 label('.sysLsrw3b')
 st([vAC+1])                     #45
-ld(-52/2)                       #46
+ld(-52//2)                      #46
 ld(hi('REENTER'),Y)             #47
 jmp(Y,'REENTER')                #48
 #nop()                          #49
@@ -2430,7 +2440,7 @@ label('.sysLsrw4b')
 st([vAC+1])                     #44
 ld(hi('REENTER'),Y)             #45
 jmp(Y,'REENTER')                #46
-ld(-50/2)                       #47
+ld(-50//2)                      #47
 
 label('SYS_LSRW5_50')
 ld(hi('shiftTable'),Y);         C('Logical shift right 5 bit (X >> 5)')#15
@@ -2458,7 +2468,7 @@ jmp(Y,AC)                       #38
 bra(255);                       C('bra $%04x' % (shiftTable+255))#39
 label('.sysLsrw5b')
 st([vAC+1])                     #44
-ld(-50/2)                       #45
+ld(-50//2)                      #45
 ld(hi('REENTER'),Y)             #46
 jmp(Y,'REENTER')                #47
 #nop()                          #48
@@ -2490,7 +2500,7 @@ label('.sysLsrw6b')
 st([vAC+1])                     #42
 ld(hi('REENTER'),Y)             #43
 jmp(Y,'REENTER')                #44
-ld(-48/2)                       #45
+ld(-48//2)                      #45
 
 label('SYS_LSLW4_46')
 ld(hi('shiftTable'),Y);         C('Logical shift left 4 bit (X << 4)')#15
@@ -2516,7 +2526,7 @@ adda(AC)                        #36
 adda(AC)                        #37
 adda(AC)                        #38
 st([vAC])                       #39
-ld(-46/2)                       #40
+ld(-46//2)                      #40
 ld(hi('REENTER'),Y)             #41
 jmp(Y,'REENTER')                #42
 #nop()                          #43
@@ -2545,7 +2555,7 @@ label('txReturn')
 st([sysArgs+2])                 #34
 ld(hi('REENTER'),Y)             #35
 jmp(Y,'REENTER')                #36
-ld(-40/2)                       #37
+ld(-40//2)                      #37
 
 def trampoline3a():
   """Read 3 bytes from ROM page"""
@@ -2628,7 +2638,7 @@ st([sysArgs+0]);                C('-> Pixel 0')#50
 
 ld(hi('REENTER'),Y)             #51
 jmp(Y,'REENTER')                #52
-ld(-56/2)                       #53
+ld(-56//2)                      #53
 
 #-----------------------------------------------------------------------
 #       v6502 right shift instruction
@@ -2640,7 +2650,7 @@ st([Y,X])                       #31
 st([v6502_Qz]);                 C('Z flag')#32
 st([v6502_Qn]);                 C('N flag')#33
 ld(hi('v6502_next'),Y)          #34
-ld(-38/2)                       #35
+ld(-38//2)                      #35
 jmp(Y,'v6502_next')             #36
 #nop()                          #37 Overlap
 #
@@ -2652,7 +2662,7 @@ st([v6502_Qz]);                 C('Z flag')#41
 st([v6502_Qn]);                 C('N flag')#42
 ld(hi('v6502_next'),Y)          #43
 jmp(Y,'v6502_next')             #44
-ld(-46/2)                       #45
+ld(-46//2)                      #45
 
 #-----------------------------------------------------------------------
 #       Reserved
@@ -2670,7 +2680,7 @@ align(0x100, 0x100)
 
 label('font32up')
 for ch in range(32, 32+50):
-  comment = 'Char %s' % repr(chr(ch))
+  comment = 'Char %s' % repr(chr(ch)).lstrip('u')
   for byte in font.font[ch-32]:
     ld(byte)
     comment = C(comment)
@@ -2683,7 +2693,7 @@ align(0x100, 0x100)
 
 label('font82up')
 for ch in range(32+50, 132):
-  comment = 'Char %s' % repr(chr(ch))
+  comment = 'Char %s' % repr(chr(ch)).lstrip('u')
   for byte in font.font[ch-32]:
     ld(byte)
     comment = C(comment)
@@ -2703,11 +2713,11 @@ label('notesTable')
 ld(0)
 ld(0)
 for i in range(0, 250, 2):
-  j = i/2-1
+  j = i//2-1
   freq = 440.0*2.0**((j-57)/12.0)
   if j>=0 and freq <= sampleRate/2.0:
     key = int(round(32768 * freq / sampleRate))
-    octave, note = j/12, notes[j%12]
+    octave, note = j//12, notes[j%12]
     sharp = '-' if notes[j%12-1] != note else '#'
     comment = '%s%s%s (%0.1f Hz)' % (note, sharp, octave, freq)
     ld(key&127); C(comment)
@@ -2805,7 +2815,7 @@ label('invTable')
 
 # Unit 64, table offset 16 (=1/4), value offset 1: (x+16)*(y+1) == 64*64 - e
 for i in range(251):
-  ld(4096/(i+16)-1)
+  ld(4096//(i+16)-1)
 
 trampoline()
 
@@ -3071,7 +3081,7 @@ ld([Y,X])                       #42(!) No change
 st([Y,X])                       #43
 ld(hi('NEXTY'),Y)               #44 Return
 jmp(Y,'NEXTY');                 C('All done')#45
-ld(-48/2)                       #46
+ld(-48//2)                      #46
 label('.sysSb#21')
 nop()                           #21
 st([sysArgs+0])                 #22
@@ -3097,7 +3107,7 @@ adda([vPC])                     #39
 st([vPC])                       #40
 ld(hi('REENTER'),Y)             #41
 jmp(Y,'REENTER')                #42
-ld(-46/2)                       #43
+ld(-46//2)                      #43
 
 # SYS_SetMode_80 implementation
 label('sys_SetMode')
@@ -3116,7 +3126,7 @@ assert videoZ == 0x0100
 st([vReturn]);                  C('DISABLE video/audio/serial/etc')#29
 nop();                          C('Ignore and return')#29(!)
 jmp(Y,'REENTER')                #30
-ld(-34/2)                       #31
+ld(-34//2)                      #31
 label('.sysSm#25')
 ld([vAC]);                      C('Mode 0,1,2,3')#25
 anda(3)                         #26
@@ -3155,7 +3165,7 @@ ld('nopixels')                  #44
 label('.sysSm#45')
 st([videoModeD])                #45
 jmp(Y,'REENTER')                #46
-ld(-50/2)                       #47
+ld(-50//2)                      #47
 
 # SYS_SendSerial1_v3_80 implementation
 label('sys_SendSerial1')
@@ -3195,18 +3205,18 @@ beq('.sysSs#45')                #43
 st([vAC])                       #44 Abort after key press with non-zero error
 st([vAC+1])                     #45
 jmp(Y,'REENTER')                #46
-ld(-50/2)                       #47
+ld(-50//2)                      #47
 label('.sysSs#45')
 ld([vPC])                       #45 Continue sending bits
 suba(2)                         #46
 st([vPC])                       #47
 jmp(Y,'REENTER')                #48
-ld(-52/2)                       #49
+ld(-52//2)                      #49
 label('.sysSs#40')
 st([vAC])                       #40 Stop sending bits, no error
 st([vAC+1])                     #41
 jmp(Y,'REENTER')                #42
-ld(-46/2)                       #43
+ld(-46//2)                      #43
 
 # CALLI implementation (vCPU instruction)
 label('calli#13')
@@ -3302,7 +3312,7 @@ ld(-1)                          #20    vAC > variable
 # No-operation for CMPHS/CMPHU when high bits are equal
 label('.cmphu#18')
 jmp(Y,'REENTER')                #18
-ld(-22/2)                       #19
+ld(-22//2)                      #19
 
 #-----------------------------------------------------------------------
 #
@@ -3372,7 +3382,7 @@ st([sysArgs+0])                 #27
 nop()                           #28
 ld(hi('REENTER'),Y);            C('Normal exit (no self-repeat)')#29
 jmp(Y,'REENTER')                #30
-ld(-34/2)                       #31
+ld(-34//2)                      #31
 
 label('.sysDpx0')
 st([sysArgs+2]);                C('Gobble 6 pixels into buffer')#20
@@ -3419,7 +3429,7 @@ suba(2)                         #57
 st([vPC])                       #58
 ld(hi('REENTER'),Y)             #59
 jmp(Y,'REENTER')                #60
-ld(-64/2)                       #61
+ld(-64//2)                      #61
 
 align(64)
 label('SYS_Sprite6x_v3_64')
@@ -3441,7 +3451,7 @@ st([sysArgs+0])                 #27
 nop()                           #28
 ld(hi('REENTER'),Y);            C('Normal exit (no self-repeat)')#29
 jmp(Y,'REENTER')                #30
-ld(-34/2)                       #31
+ld(-34//2)                      #31
 
 label('.sysDpx1')
 st([sysArgs+7]);                C('Gobble 6 pixels into buffer (backwards)')#20
@@ -3486,7 +3496,7 @@ suba(2)                         #55
 st([vPC])                       #56
 ld(hi('REENTER'),Y)             #57
 jmp(Y,'REENTER')                #58
-ld(-62/2)                       #59
+ld(-62//2)                      #59
 
 align(64)
 label('SYS_Sprite6y_v3_64')
@@ -3510,7 +3520,7 @@ st([sysArgs+0])                 #29
 nop()                           #30
 ld(hi('REENTER'),Y);            C('Normal exit (no self-repeat)')#31
 jmp(Y,'REENTER')                #32
-ld(-36/2)                       #33
+ld(-36//2)                      #33
 
 label('.sysDpx2')
 st([sysArgs+2]);                C('Gobble 6 pixels into buffer')#20
@@ -3557,7 +3567,7 @@ suba(2)                         #57
 st([vPC])                       #58
 ld(hi('REENTER'),Y)             #59
 jmp(Y,'REENTER')                #60
-ld(-64/2)                       #61
+ld(-64//2)                      #61
 
 align(64)
 label('SYS_Sprite6xy_v3_64')
@@ -3581,7 +3591,7 @@ st([sysArgs+0])                 #29
 nop()                           #30
 ld(hi('REENTER'),Y);            C('Normal exit (no self-repeat)')#31
 jmp(Y,'REENTER')                #32
-ld(-36/2)                       #33
+ld(-36//2)                      #33
 
 label('.sysDpx3')
 st([sysArgs+7]);                C('Gobble 6 pixels into buffer (backwards)')#20
@@ -3626,7 +3636,7 @@ suba(2)                         #55
 st([vPC])                       #56
 ld(hi('REENTER'),Y)             #57
 jmp(Y,'REENTER')                #58
-ld(-62/2)                       #59
+ld(-62//2)                      #59
 
 #-----------------------------------------------------------------------
 
@@ -3657,7 +3667,7 @@ st([sysArgs+3])                 #26,27 (must be idempotent)
 nop()                           #28
 ld(hi('REENTER'),Y)             #29
 jmp(Y,'REENTER')                #30
-ld(-34/2)                       #31
+ld(-34//2)                      #31
 
 #-----------------------------------------------------------------------
 
@@ -3696,22 +3706,22 @@ suba(2)                         #125
 st([vPC])                       #126
 ld(hi('REENTER'),Y)             #127
 jmp(Y,'REENTER')                #128
-ld(-132/2)                      #129
+ld(-132//2)                     #129
 
 label('.sysSpi#125')
 ld(hi('REENTER'),Y);            C('Continue program')#125
 jmp(Y,'REENTER')                #126
-ld(-130/2)                      #127
+ld(-130//2)                     #127
 
 #-----------------------------------------------------------------------
 
 label('sys_v6502')
 
 st([vCPUselect],Y);             C('Activate v6502')#18
-ld(-22/2)                       #19
+ld(-22//2)                      #19
 jmp(Y,'v6502_ENTER');           C('Transfer control in the same time slice')#20
 adda([vTicks])                  #21
-assert (38 - 22)/2 >= v6502_adjust
+assert (38 - 22)//2 >= v6502_adjust
 
 #-----------------------------------------------------------------------
 #       MOS 6502 emulator
@@ -3731,7 +3741,7 @@ assert (38 - 22)/2 >= v6502_adjust
 label('v6502_ror')
 assert v6502_Cflag == 1
 ld([v6502_ADH],Y)               #12
-ld(-46/2+v6502_maxTicks)        #13 Is there enough time for the excess ticks?
+ld(-46//2+v6502_maxTicks)        #13 Is there enough time for the excess ticks?
 adda([vTicks])                  #14
 blt('.recheck17')               #15
 ld([v6502_P]);                  C('Transfer C to "bit 8"')#16
@@ -3756,7 +3766,7 @@ bra(255);                       C('bra $%04x' % (shiftTable+255))#34
 label('.recheck17')
 ld(hi('v6502_check'),Y)         #17 Go back to time check before dispatch
 jmp(Y,'v6502_check')            #18
-ld(-20/2)                       #19
+ld(-20//2)                      #19
 
 label('v6502_lsr')
 assert v6502_Cflag == 1
@@ -3796,7 +3806,7 @@ ld([v6502_Tmp],X)               #25
 ora([X])                        #26
 st([v6502_P])                   #27
 ld(hi('v6502_next'),Y)          #28
-ld(-32/2)                       #29
+ld(-32//2)                      #29
 jmp(Y,'v6502_next')             #30
 #nop()                          #31 Overlap
 #
@@ -3816,7 +3826,7 @@ ld([v6502_ADH])                 #15
 st([v6502_PCH])                 #16
 ld(hi('v6502_next'),Y)          #17
 jmp(Y,'v6502_next')             #18
-ld(-20/2)                       #19
+ld(-20//2)                      #19
 
 label('v6502_jmp2')
 nop()                           #12
@@ -3828,7 +3838,7 @@ ld([Y,X])                       #17
 st([v6502_PCH])                 #18
 ld(hi('v6502_next'),Y)          #19
 jmp(Y,'v6502_next')             #20
-ld(-22/2)                       #21
+ld(-22//2)                      #21
 
 label('v6502_pla')
 ld([v6502_S])                   #12
@@ -3840,7 +3850,7 @@ st([v6502_A])                   #17
 st([v6502_Qz]);                 C('Z flag')#18
 st([v6502_Qn]);                 C('N flag')#19
 ld(hi('v6502_next'),Y)          #20
-ld(-24/2)                       #21
+ld(-24//2)                      #21
 jmp(Y,'v6502_next')             #22
 #nop()                          #23 Overlap
 #
@@ -3852,7 +3862,7 @@ st([v6502_S],X)                 #15
 ld([v6502_A])                   #16
 st([X])                         #17
 jmp(Y,'v6502_next')             #18
-ld(-20/2)                       #19
+ld(-20//2)                      #19
 
 label('v6502_brk')
 ld(hi('ENTER'));                C('Switch to vCPU')#12
@@ -3861,7 +3871,7 @@ assert v6502_A == vAC
 ld(0)                           #14
 st([vAC+1])                     #15
 ld(hi('REENTER'),Y)             #16 Switch in the current time slice
-ld(-22/2+v6502_adjust)          #17
+ld(-22//2+v6502_adjust)         #17
 jmp(Y,'REENTER');               #18
 nop()                           #19
 
@@ -3939,7 +3949,7 @@ ld([v6502_IR]);                 C('xxx0000')#21
 bmi('.imm24')                   #22
 ld([v6502_PCH])                 #23
 bra('v6502_check');             #24
-ld(-26/2)                       #25
+ld(-26//2)                      #25
 
 # Resync with video driver. At this point we're returning BEFORE
 # fetching and executing the next instruction.
@@ -3972,7 +3982,7 @@ ld(1)                           #31(!)
 adda([v6502_PCH])               #32
 st([v6502_PCH])                 #33
 bra('v6502_check')              #34
-ld(-36/2)                       #35
+ld(-36//2)                      #35
 
 # Accumulator Mode: ROL ROR LSL ASR -- 28 cycles
 label('v6502_modeACC')
@@ -3980,7 +3990,7 @@ ld(v6502_A&255);                C('Address of AC')#21
 st([v6502_ADL],X)               #22
 ld(v6502_A>>8)                  #23
 st([v6502_ADH])                 #24
-ld(-28/2)                       #25
+ld(-28//2)                      #25
 bra('v6502_check')              #26
 #nop()                          #27 Overlap
 #
@@ -3989,7 +3999,7 @@ label('v6502_modeILL')
 label('v6502_modeIMP')
 nop()                           #21,27
 bra('v6502_check')              #22
-ld(-24/2)                       #23
+ld(-24//2)                      #23
 
 # Zero Page Modes: $DD $DD,X $DD,Y -- 36 cycles
 label('v6502_modeZPX')
@@ -4012,7 +4022,7 @@ ld(1)                           #31(!)
 adda([v6502_PCH])               #32
 st([v6502_PCH])                 #33
 bra('v6502_check')              #34
-ld(-36/2)                       #35
+ld(-36//2)                      #35
 
 # Possible retry loop for modeABS and modeIZY. Because these need
 # more time than the v6502_maxTicks of 38 Gigatron cycles, we may
@@ -4028,7 +4038,7 @@ ld([v6502_PCL])                 #33
 suba(1)                         #34
 st([v6502_PCL])                 #35
 bra('v6502_next');              C('Retry until sufficient time')#36
-ld(-38/2)                       #37
+ld(-38//2)                      #37
 
 # Absolute Modes: $DDDD $DDDD,X $DDDD,Y -- 64 cycles
 label('v6502_modeABS')
@@ -4041,7 +4051,7 @@ ld([v6502_X])                   #21,22
 ld([v6502_Y])                   #22
 label('.abs23')
 st([v6502_ADL])                 #23
-ld(-64/2+v6502_maxTicks)        #24 Is there enough time for the excess ticks?
+ld(-64//2+v6502_maxTicks)       #24 Is there enough time for the excess ticks?
 adda([vTicks])                  #25
 blt('.retry28')                 #26
 ld([v6502_PCL])                 #27
@@ -4087,13 +4097,13 @@ adda([v6502_PCH])               #59
 st([v6502_PCH])                 #60
 ld([v6502_ADL],X)               #61
 bra('v6502_check')              #62
-ld(-64/2)                       #63
+ld(-64//2)                      #63
 
 # Indirect Indexed Mode: ($DD),Y -- 54 cycles
 label('v6502_modeIZY')
 ld(AC,X)                        #21 $DD
 ld(0,Y)                         #22 $00DD
-ld(-54/2+v6502_maxTicks)        #23 Is there enough time for the excess ticks?
+ld(-54//2+v6502_maxTicks)       #23 Is there enough time for the excess ticks?
 adda([vTicks])                  #24
 nop()                           #25
 blt('.retry28')                 #26
@@ -4128,7 +4138,7 @@ adda([v6502_ADH])               #49
 st([v6502_ADH])                 #50
 ld([v6502_ADL],X)               #51
 bra('v6502_check')              #52
-ld(-54/2)                       #53
+ld(-54//2)                      #53
 
 # Relative Mode: BEQ BNE BPL BMI BCC BCS BVC BVS -- 36 cycles
 label('v6502_modeREL')
@@ -4148,7 +4158,7 @@ ld(1)                           #31(!)
 adda([v6502_PCH])               #32
 st([v6502_PCH])                 #33
 bra('v6502_check')              #34
-ld(-36/2)                       #53
+ld(-36//2)                      #53
 
 # Indexed Indirect Mode: ($DD,X) -- 38 cycles
 label('v6502_modeIZX')
@@ -4169,7 +4179,7 @@ ld(0)                           #34
 ld(1)                           #34(!)
 adda([v6502_PCH])               #35
 st([v6502_PCH])                 #36
-ld(-38/2)                       #37 !!! Fall through to v6502_check !!!
+ld(-38//2)                      #37 !!! Fall through to v6502_check !!!
 #
 # Update elapsed time for the addressing mode processing.
 # Then check if we can immediately execute this instruction.
@@ -4308,7 +4318,7 @@ ora([v6502_Tmp])                #33
 st([v6502_P])                   #34
 ld(hi('v6502_next'),Y)          #35
 jmp(Y,'v6502_next')             #36
-ld(-38/2)                       #37
+ld(-38//2)                      #37
 # Cin=1, A=$FF, B=$DD --> Result=$DD, Cout=1, V=0
 # Cin=0, A=$00, B=$DD --> Result=$DD, Cout=0, V=0
 label('.adc14')
@@ -4319,7 +4329,7 @@ ld([v6502_P])                   #17
 anda(0x7f);                     C('V=0, keep C')#18
 st([v6502_P])                   #19
 ld(hi('v6502_next'),Y)          #20
-ld(-24/2)                       #21
+ld(-24//2)                      #21
 jmp(Y,'v6502_next')             #22
 #nop()                          #23 Overlap
 #
@@ -4340,7 +4350,7 @@ ld(0x69);                       C('ADC #$xx')#17 Any ADC opcode will do
 st([v6502_IR])                  #18
 ld(hi('v6502_check'),Y)         #20 Go back to time check before dispatch
 jmp(Y,'v6502_check')            #20
-ld(-22/2)                       #21
+ld(-22//2)                      #21
 
 # Carry calculation table
 #   L7 R7 C7   RX UC SC
@@ -4374,7 +4384,7 @@ st([v6502_P])                   #12
 nop()                           #13
 label('.next14')
 jmp(Y,'v6502_next')             #14
-ld(-16/2)                       #15
+ld(-16//2)                      #15
 
 label('v6502_BPL')
 ld([v6502_Qn])                   #9
@@ -4439,7 +4449,7 @@ adda([v6502_PCH])               #23
 st([v6502_PCH])                 #24
 nop()                           #25
 jmp(Y,'v6502_next')             #26
-ld(-28/2)                       #27
+ld(-28//2)                      #27
 
 label('v6502_INX')
 nop()                           #9
@@ -4449,13 +4459,13 @@ st([v6502_X])                   #12
 label('.inx13')
 st([v6502_Qz]);                 C('Z flag')#13
 st([v6502_Qn]);                 C('N flag')#14
-ld(-18/2)                       #15
+ld(-18//2)                      #15
 jmp(Y,'v6502_next')             #16
 nop()                           #17
 
 label('.next12')
 jmp(Y,'v6502_next')             #12
-ld(-14/2)                       #13
+ld(-14//2)                      #13
 
 label('v6502_DEX')
 ld([v6502_X])                   #9
@@ -4476,7 +4486,7 @@ bra('.inx13')                   #11
 st([v6502_Y])                   #12
 
 label('v6502_NOP')
-ld(-12/2)                       #9
+ld(-12//2)                      #9
 jmp(Y,'v6502_next')             #10
 #nop()                          #11 Overlap
 #
@@ -4503,7 +4513,7 @@ st([v6502_A])                   #13
 st([v6502_Qz]);                 C('Z flag')#14
 st([v6502_Qn]);                 C('N flag')#15
 ld(hi('v6502_next'),Y)          #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 jmp(Y,'v6502_next')             #18
 #nop()                          #19 Overlap
 #
@@ -4543,7 +4553,7 @@ ld([v6502_PCH],Y)               #31
 ld([Y,X])                       #32
 st([v6502_PCH])                 #33
 ld(hi('v6502_next'),Y)          #34
-ld(-38/2)                       #35
+ld(-38//2)                      #35
 jmp(Y,'v6502_next')             #36
 #nop()                          #37 Overlap
 #
@@ -4718,7 +4728,7 @@ st([Y,X])                       #15
 st([v6502_Qz]);                 C('Z flag')#16
 st([v6502_Qn]);                 C('N flag')#17
 ld(hi('v6502_next'),Y)          #18
-ld(-22/2)                       #19
+ld(-22//2)                      #19
 jmp(Y,'v6502_next')             #20
 #nop()                          #21 Overlap
 #
@@ -4730,7 +4740,7 @@ st([Y,X])                       #15
 st([v6502_Qz]);                 C('Z flag')#16
 st([v6502_Qn]);                 C('N flag')#17
 ld(hi('v6502_next'),Y)          #18
-ld(-22/2)                       #19
+ld(-22//2)                      #19
 jmp(Y,'v6502_next')             #20
 nop()                           #21
 
@@ -4745,7 +4755,7 @@ st([v6502_Qn]);                 C('N flag')#17
 nop()                           #18
 ld(hi('v6502_next'),Y)          #19
 jmp(Y,'v6502_next')             #20
-ld(-22/2)                       #21
+ld(-22//2)                      #21
 
 label('v6502_ldx')
 ld([v6502_ADH],Y)               #12
@@ -4769,7 +4779,7 @@ st([v6502_Qz]);                 C('Z flag')#17
 st([v6502_Qn]);                 C('N flag')#18
 ld(hi('v6502_next'),Y)          #19
 jmp(Y,'v6502_next')             #20
-ld(-22/2)                       #21
+ld(-22//2)                      #21
 
 label('v6502_sta')
 ld([v6502_ADH],Y)               #12
@@ -4777,7 +4787,7 @@ ld([v6502_A])                   #13
 st([Y,X])                       #14
 ld(hi('v6502_next'),Y)          #15
 jmp(Y,'v6502_next')             #16
-ld(-18/2)                       #17
+ld(-18//2)                      #17
 
 label('v6502_stx')
 ld([v6502_ADH],Y)               #12
@@ -4785,7 +4795,7 @@ ld([v6502_X])                   #13
 st([Y,X])                       #14
 ld(hi('v6502_next'),Y)          #15
 jmp(Y,'v6502_next')             #16
-ld(-18/2)                       #17
+ld(-18//2)                      #17
 
 label('v6502_stx2')
 ld([v6502_ADL]);                C('Special case $96: STX $DD,Y')#12
@@ -4795,7 +4805,7 @@ ld([v6502_X])                   #15
 st([X])                         #16
 ld(hi('v6502_next'),Y)          #17
 jmp(Y,'v6502_next')             #18
-ld(-20/2)                       #19
+ld(-20//2)                      #19
 
 label('v6502_sty')
 ld([v6502_ADH],Y)               #12
@@ -4804,7 +4814,7 @@ st([Y,X])                       #14
 ld(hi('v6502_next'),Y)          #15
 jmp(Y,'v6502_next')             #16
 label('v6502_tax')
-ld(-18/2)                       #17,12
+ld(-18//2)                      #17,12
 #
 #label('v6502_tax')
 #nop()                          #12 Overlap
@@ -4816,7 +4826,7 @@ st([v6502_Qn]);                 C('N flag')#16
 ld(hi('v6502_next'),Y)          #17
 jmp(Y,'v6502_next')             #18
 label('v6502_tsx')
-ld(-20/2)                       #19
+ld(-20//2)                      #19
 #
 #label('v6502_tsx')
 #nop()                          #12 Overlap
@@ -4829,7 +4839,7 @@ st([v6502_Qn]);                 C('N flag')#17
 nop()                           #18
 ld(hi('v6502_next'),Y)          #19
 jmp(Y,'v6502_next')             #20
-ld(-22/2)                       #21
+ld(-22//2)                      #21
 
 label('v6502_txs')
 ld([v6502_X])                   #12
@@ -4880,7 +4890,7 @@ anda(~v6502_Vemu)               #14
 label('.clv15')
 st([v6502_P])                   #15
 ld(hi('v6502_next'),Y)          #16
-ld(-20/2)                       #17
+ld(-20//2)                      #17
 jmp(Y,'v6502_next')             #18
 label('v6502_bit')
 nop()                           #19,12
@@ -4903,7 +4913,7 @@ ora([v6502_P])                  #25
 st([v6502_P])                   #26 Update V
 ld(hi('v6502_next'),Y)          #27
 jmp(Y,'v6502_next')             #28
-ld(-30/2)                       #29
+ld(-30//2)                      #29
 
 label('v6502_rts')
 ld([v6502_S])                   #12
@@ -4924,7 +4934,7 @@ st([v6502_PCH])                 #25
 nop()                           #26
 ld(hi('v6502_next'),Y)          #27
 jmp(Y,'v6502_next')             #28
-ld(-30/2)                       #29
+ld(-30//2)                      #29
 
 label('v6502_php')
 ld([v6502_S])                   #12
@@ -4951,7 +4961,7 @@ st([X])                         #31
 nop()                           #32
 ld(hi('v6502_next'),Y)          #33
 jmp(Y,'v6502_next')             #34
-ld(-36/2)                       #35
+ld(-36//2)                      #35
 
 label('v6502_cpx')
 bra('.cmp14')                   #12
@@ -4987,7 +4997,7 @@ ora([X])                        #25
 st([v6502_P])                   #26
 ld(hi('v6502_next'),Y)          #27
 jmp(Y,'v6502_next')             #28
-ld(-30/2)                       #29
+ld(-30//2)                      #29
 
 label('v6502_plp')
 assert v6502_Nflag == 128
@@ -5007,7 +5017,7 @@ adda(v6502_Vflag)               #23
 st([v6502_P]);                  C('All other flags')#24
 ld(hi('v6502_next'),Y)          #25
 jmp(Y,'v6502_next')             #26
-ld(-28/2)                       #27
+ld(-28//2)                      #27
 
 label('v6502_rti')
 ld([v6502_S])                   #12
@@ -5033,7 +5043,7 @@ st([v6502_PCH])                 #31
 nop()                           #32
 ld(hi('v6502_next'),Y)          #33
 jmp(Y,'v6502_next')             #34
-ld(-36/2)                       #35
+ld(-36//2)                      #35
 
 #-----------------------------------------------------------------------
 #       More SYS functions
@@ -5112,7 +5122,7 @@ st('RET',     [Y,Xpp]);C('RET') #82 *+52 Return
 # Return to interpreter
 ld(hi('REENTER'),Y)             #83
 jmp(Y,'REENTER')                #84
-ld(-88/2)                       #85
+ld(-88//2)                      #85
 
 # SYS_ResetWaveforms_v4_50 implementation
 label('sys_ResetWaveforms')
@@ -5148,7 +5158,7 @@ adda([vPC])                     #43
 st([vPC])                       #44
 ld(hi('REENTER'),Y)             #45
 jmp(Y,'REENTER')                #46
-ld(-50/2)                       #47
+ld(-50//2)                      #47
 
 # SYS_ShuffleNoise_v4_46 implementation
 label('sys_ShuffleNoise')
@@ -5177,7 +5187,7 @@ adda([vPC])                     #38
 st([vPC])                       #39
 ld(hi('NEXTY'),Y)               #40
 jmp(Y,'NEXTY')                  #41
-ld(-44/2)                       #42
+ld(-44//2)                      #42
 
 #-----------------------------------------------------------------------
 #
@@ -5253,7 +5263,7 @@ def basicLine(address, number, text):
   s = head + body
   assert len(s) > 0
   for i, byte in enumerate([address>>8, address&255, len(s)]+s):
-    comment = repr(chr(byte)) if i >= 3+len(head) else None
+    comment = repr(chr(byte)).lstrip('u') if i >= 3+len(head) else None
     program.putInRomTable(byte, comment=comment)
 
 #-----------------------------------------------------------------------
@@ -5266,7 +5276,7 @@ if pc()&255 > 251:              # Don't start in a trampoline region
 #-----------------------------------------------------------------------
 
 for application in argv[1:]:
-  print
+  print()
 
   # Determine label
   if '=' in application:
@@ -5276,7 +5286,7 @@ for application in argv[1:]:
     # Label derived from filename itself
     name = application.rsplit('.', 1)[0] # Remove extension
     name = name.rsplit('/', 1)[-1]       # Remove path
-  print 'Processing file %s label %s' % (application, name)
+  print('Processing file %s label %s' % (application, name))
 
   C('+-----------------------------------+')
   C('| %-33s |' % application)
@@ -5284,21 +5294,21 @@ for application in argv[1:]:
 
   # Pre-compiled GT1 files
   if application.endswith(('.gt1', '.gt1x')):
-    print 'Load type .gt1 at $%04x' % pc()
+    print('Load type .gt1 at $%04x' % pc())
     with open(application, 'rb') as f:
-      raw = f.read()
+      raw = bytearray(f.read())
     label(name)
     raw = raw[:-2] # Drop start address
-    if ord(raw[0]) == 0 and ord(raw[1]) + ord(raw[2]) > 0xc0:
-      print 'Warning: zero-page conflict with ROM loader (SYS_Exec_88)'
+    if raw[0] == 0 and raw[1] + raw[2] > 0xc0:
+      print('Warning: zero-page conflict with ROM loader (SYS_Exec_88)')
     program = gcl.Program(None)
     for byte in raw:
-      program.putInRomTable(ord(byte))
+      program.putInRomTable(byte)
     program.end()
 
   # GCL files
   elif application.endswith('.gcl'):
-    print 'Compile type .gcl at $%04x' % pc()
+    print('Compile type .gcl at $%04x' % pc())
     label(name)
     program = gcl.Program(name)
     program.org(userCode)
@@ -5309,20 +5319,20 @@ for application in argv[1:]:
 
   # Application-specific SYS extensions
   elif application.endswith('.py'):
-    print 'Include type .py at $%04x' % pc()
+    print('Include type .py at $%04x' % pc())
     label(name)
     importlib.import_module(name)
 
   # GTB files
   elif application.endswith('.gtb'):
-    print 'Link type .gtb at $%04x' % pc()
+    print('Link type .gtb at $%04x' % pc())
     zpReset(userVars)
     label(name)
     program = gcl.Program(name)
     # BasicProgram comes from TinyBASIC.gcl
     address = symbol('BasicProgram')
     if not has(address):
-      print ' Error: TinyBASIC must be compiled-in first'
+      print(' Error: TinyBASIC must be compiled-in first')
     program.org(address)
     i = 0
     for line in open(application):
@@ -5343,42 +5353,42 @@ for application in argv[1:]:
     basicLine(symbol('Buffer'), address, None)  # End of program
     program.putInRomTable(0)
     program.end()
-    print ' Lines', i
+    print(' Lines', i)
 
   # Simple sequential RGB file (for Racer horizon image)
   elif application.endswith('-256x16.rgb'):
     width, height = 256, 16
-    print 'Convert type .rgb/sequential at $%04x' % pc()
+    print('Convert type .rgb/sequential at $%04x' % pc())
     f = open(application, 'rb')
-    raw = f.read()
+    raw = bytearray(f.read())
     f.close()
     label(name)
     packed, quartet = [], []
-    for i in xrange(0, len(raw), 3):
-      R, G, B = ord(raw[i+0]), ord(raw[i+1]), ord(raw[i+2])
-      quartet.append((R/85) + 4*(G/85) + 16*(B/85))
+    for i in range(0, len(raw), 3):
+      R, G, B = raw[i+0], raw[i+1], raw[i+2]
+      quartet.append((R//85) + 4*(G//85) + 16*(B//85))
       if len(quartet) == 4:
         # Pack 4 pixels in 3 bytes
         packed.append( ((quartet[0]&0b111111)>>0) + ((quartet[1]&0b000011)<<6) )
         packed.append( ((quartet[1]&0b111100)>>2) + ((quartet[2]&0b001111)<<4) )
         packed.append( ((quartet[2]&0b110000)>>4) + ((quartet[3]&0b111111)<<2) )
         quartet = []
-    for i in xrange(len(packed)):
+    for i in range(len(packed)):
       ld(packed[i])
       if pc()&255 == 251:
         trampoline()
-    print ' Pixels %dx%d' % (width, height)
+    print(' Pixels %dx%d' % (width, height))
 
   # XXX Provisionally bring ROMv1 egg back as placeholder for Pictures
   elif application.endswith('/gigatron.rgb'):
-    print('Convert type gigatron.rgb at $%04x' % pc())
+    print(('Convert type gigatron.rgb at $%04x' % pc()))
     f = open(application, 'rb')
-    raw = f.read()
+    raw = bytearray(f.read())
     f.close()
     label(name)
-    for i in xrange(len(raw)):
+    for i in range(len(raw)):
       if pc()&255 < 251:
-        ld(ord(raw[i]))
+        ld(raw[i])
       elif pc()&255 == 251:
         trampoline()
 
@@ -5386,9 +5396,9 @@ for application in argv[1:]:
     assert False
 
   C('End of %s, size %d' % (application, pc() - symbol(name)))
-  print ' Size %s' % (pc() - symbol(name))
+  print(' Size %s' % (pc() - symbol(name)))
 
-print
+print()
 
 #-----------------------------------------------------------------------
 # End of embedded applications

--- a/Core/gcl0x.py
+++ b/Core/gcl0x.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
-from __future__ import print_function
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 # XXX Change to Python3
 # XXX Backquoted words should have precedence over grouping
@@ -157,7 +162,7 @@ class Program:
       # Words with constant value as operand
       elif has(con):
         if not has(op):
-          if 0 <= con < 256:
+          if isinstance(con, int) and 0 <= con < 256:
             self.emitOp('LDI')
           else:
             self.emitOp('LDWI').emit(lo(con)); con = hi(con)
@@ -341,7 +346,7 @@ class Program:
     # Convert maximum Gigatron cycles to the negative of excess ticks
     if con & 1:
       self.error('Invalid value (must be even, got %d)' % con)
-    extraTicks = con/2 - symbol('maxTicks')
+    extraTicks = con//2 - symbol('maxTicks')
     return 256 - extraTicks if extraTicks > 0 else 0
 
   def emitQuote(self, var):
@@ -352,7 +357,7 @@ class Program:
     else:
       d = '`' # And symbol becomes a backquote
     for c in d:
-      comment = '%04x %s' % (self.vPC, repr(c))
+      comment = '%04x %s' % (self.vPC, repr(c).lstrip('u'))
       self.emit(ord(c), comment=comment)
 
   def emitDef(self):
@@ -426,7 +431,7 @@ class Program:
       if var not in self.vars:
         self.vars[var] = zpByte(2)
       address = self.vars[var]
-    comment = '%04x %s' % (prev(self.vPC, 1), repr(var))
+    comment = '%04x %s' % (prev(self.vPC, 1), repr(var).lstrip('u'))
     comment += '%+d' % offset if offset else ''
     byte = address + offset
     if byte < -128 or byte >= 256:


### PR DESCRIPTION
Partial fix for #121. This includes all of the files required to build the dev. ROM, but not
any of the files needed for the older roms.

Support for Python 2.7 is retained. Running dev.py in Python3 results
in the same ROM image as when running in Python 2, which is itself
unchanged from before these changes.

The changes are mostly print and division related, although there are
some bytes/string changes too.