### PR TITLE
Ver 0.8.22

### DIFF
--- a/Contrib/at67/assembler.cpp
+++ b/Contrib/at67/assembler.cpp
@@ -112,7 +112,7 @@ namespace Assembler
     uint16_t _currDasmByteCount = 1, _prevDasmByteCount = 1;
     uint16_t _currDasmPageByteCount = 0, _prevDasmPageByteCount = 0;
 
-    std::string _includePath = "";
+    std::string _includePath = ".";
 
     std::vector<Label> _labels;
     std::vector<Equate> _equates;

--- a/Contrib/at67/cpu.cpp
+++ b/Contrib/at67/cpu.cpp
@@ -46,6 +46,7 @@ namespace Cpu
     bool _checkRomType = true;
     bool _debugging = false;
     bool _initAudio = true;
+    bool _consoleSaveFile = true;
 
     std::vector<uint8_t> _RAM;
     uint8_t _ROM[ROM_SIZE][2];
@@ -490,6 +491,8 @@ namespace Cpu
     HWND _consoleWindowHWND;
     void restoreWin32Console(void)
     {
+        if(!_consoleSaveFile) return;
+
         std::string line;
         std::ifstream infile(Editor::getCwdPath() + "/" + "console.txt");
         if(infile.is_open())
@@ -510,6 +513,8 @@ namespace Cpu
 
     void saveWin32Console(void)
     {
+        if(!_consoleSaveFile) return;
+
         RECT rect;
         if(GetWindowRect(_consoleWindowHWND, &rect))
         {
@@ -523,6 +528,11 @@ namespace Cpu
                 outfile << xpos << " " << ypos << " " << width << " " << height << std::endl;
             }
         }
+    }
+
+    void enableWin32ConsoleSaveFile(bool consoleSaveFile)
+    {
+        _consoleSaveFile = consoleSaveFile;
     }
 #endif
 
@@ -1039,7 +1049,7 @@ namespace Cpu
             Audio::fillCallbackBuffer();
 
             // Loader
-            Loader::upload(_vgaY);
+            if(_clock > STARTUP_DELAY_CLOCKS*10.0) Loader::upload(_vgaY);
 
             // Horizontal timing errors
             if(_vgaY >= 0  &&  _vgaY < SCREEN_HEIGHT)

--- a/Contrib/at67/cpu.h
+++ b/Contrib/at67/cpu.h
@@ -94,6 +94,7 @@ namespace Cpu
 
 #ifdef _WIN32
     void restoreWin32Console(void);
+    void enableWin32ConsoleSaveFile(bool consoleSaveFile);
 #endif
     
     void loadRom(int index);

--- a/Contrib/at67/editor.cpp
+++ b/Contrib/at67/editor.cpp
@@ -219,6 +219,10 @@ namespace Editor
         if(removeSlash  &&  str.length()) str.erase(str.length()-1);
         return str;
     }
+    void setBrowserPath(const std::string& path)
+    {
+        _filePath = path;
+    }
 
     bool scanCodeFromIniKey(const std::string& sectionString, const std::string& iniKey, const std::string& defaultKey, KeyCodeMod& keyCodeMod)
     {

--- a/Contrib/at67/editor.h
+++ b/Contrib/at67/editor.h
@@ -140,6 +140,7 @@ namespace Editor
     void getMouseMenuCursor(int& x, int& y, int& cy);
 
     std::string getBrowserPath(bool removeSlash=false);
+    void setBrowserPath(const std::string& path);
 
     int getEmulatorScanCode(const std::string& keyWord);
 #ifndef STAND_ALONE

--- a/Contrib/at67/graphics.cpp
+++ b/Contrib/at67/graphics.cpp
@@ -273,8 +273,8 @@ namespace Graphics
         _filter = 0;
         _width = 640;
         _height = 480;
-        _scaleX = 1.5f;
-        _scaleY = 1.5f;
+        _scaleX = 2.0f;
+        _scaleY = 2.0f;
         _posX = 40;
         _posY = 40;
 
@@ -324,9 +324,9 @@ namespace Graphics
                         getKeyAsString(sectionString, "Height", "480", result);
                         _height = (result == "DESKTOP") ? DM.h : std::strtol(result.c_str(), nullptr, 10);
 
-                        getKeyAsString(sectionString, "ScaleX", "1.5", result);
+                        getKeyAsString(sectionString, "ScaleX", "2.0", result);
                         _scaleX = std::stof(result.c_str());
-                        getKeyAsString(sectionString, "ScaleY", "1.5", result);
+                        getKeyAsString(sectionString, "ScaleY", "2.0", result);
                         _scaleY = std::stof(result.c_str());
 
                         getKeyAsString(sectionString, "PosX", "0", result);

--- a/Contrib/at67/graphics.cpp
+++ b/Contrib/at67/graphics.cpp
@@ -273,8 +273,8 @@ namespace Graphics
         _filter = 0;
         _width = 640;
         _height = 480;
-        _scaleX = 2.0f;
-        _scaleY = 2.0f;
+        _scaleX = 1.5f;
+        _scaleY = 1.5f;
         _posX = 40;
         _posY = 40;
 
@@ -324,9 +324,9 @@ namespace Graphics
                         getKeyAsString(sectionString, "Height", "480", result);
                         _height = (result == "DESKTOP") ? DM.h : std::strtol(result.c_str(), nullptr, 10);
 
-                        getKeyAsString(sectionString, "ScaleX", "2.0", result);
+                        getKeyAsString(sectionString, "ScaleX", "1.5", result);
                         _scaleX = std::stof(result.c_str());
-                        getKeyAsString(sectionString, "ScaleY", "2.0", result);
+                        getKeyAsString(sectionString, "ScaleY", "1.5", result);
                         _scaleY = std::stof(result.c_str());
 
                         getKeyAsString(sectionString, "PosX", "0", result);

--- a/Contrib/at67/loader.cpp
+++ b/Contrib/at67/loader.cpp
@@ -311,6 +311,7 @@ namespace Loader
 
     std::vector<ConfigRom> _configRoms;
 
+    std::string _launchName = "";
     std::string _currentGame = "";
 
     INIReader _configIniReader;
@@ -318,7 +319,9 @@ namespace Loader
     std::map<std::string, SaveData> _saveData;
 
 
+    std::string& getLaunchName(void) {return _launchName;}
     std::string& getCurrentGame(void) {return _currentGame;}
+    void setLaunchName(const std::string& launchName) {_launchName = launchName;}
     void setCurrentGame(const std::string& currentGame) {_currentGame = currentGame;}
 
     UploadTarget getUploadTarget(void) {return _uploadTarget;}
@@ -1075,7 +1078,7 @@ namespace Loader
         return true;
     }
 
-    void uploadDirect(UploadTarget uploadTarget)
+    void uploadDirect(UploadTarget uploadTarget, const std::string& name, const std::string path)
     {
         Gt1File gt1File;
 
@@ -1085,11 +1088,11 @@ namespace Loader
         bool hasRomCode = false;
         bool hasRamCode = false;
 
-        uint16_t executeAddress = Editor::getLoadBaseAddress();
-        std::string filename = *Editor::getCurrentFileEntryName();
-        std::string filepath = std::string(Editor::getBrowserPath() + filename);
+        uint16_t executeAddress;
         std::string gtbFilepath;
 
+        std::string filename = name;
+        std::string filepath = path + name;
         size_t nameSuffix = filename.find_last_of(".");
         size_t pathSuffix = filepath.find_last_of(".");
         if(nameSuffix == std::string::npos  ||  pathSuffix == std::string::npos)
@@ -1128,7 +1131,9 @@ namespace Loader
                 return;
             }
 
-            std::string command = "python3 -B Core/compilegcl.py -s interface.json \"" + filepath + "\" \"" + browserPath + "\"";
+            size_t slash = filepath.find_last_of("\\/");
+            std::string gclPath = (slash != std::string::npos) ? filepath.substr(0, slash) : browserPath;
+            std::string command = "python3 -B Core/compilegcl.py -s interface.json \"" + filepath + "\" \"" + gclPath + "\"";
             //fprintf(stderr, command.c_str());
 
             // Create gt1 name and path
@@ -1443,7 +1448,10 @@ namespace Loader
             uint16_t executeAddress = Editor::getLoadBaseAddress();
             if(_uploadTarget != None)
             {
-                uploadDirect(_uploadTarget);
+                std::string filename = (Editor::getCurrentFileEntryName()) ? *Editor::getCurrentFileEntryName() : _launchName;
+                std::string filepath = Editor::getBrowserPath();
+
+                uploadDirect(_uploadTarget, filename, filepath);
                 _uploadTarget = None;
 
                 return;

--- a/Contrib/at67/loader.cpp
+++ b/Contrib/at67/loader.cpp
@@ -1134,6 +1134,13 @@ namespace Loader
                 return;
             }
 
+            // Check for absolute path
+            if(filepath.find(":") == std::string::npos  &&  filepath[0] != '/')
+            {
+                filepath = Editor::getBrowserPath() + filepath;
+                pathSuffix = filepath.find_last_of(".");
+            }
+
             slash = filepath.find_last_of("\\/");
             std::string gclPath = (slash != std::string::npos) ? filepath.substr(0, slash) : "./";
             std::string command = "python3 -B Core/compilegcl.py -s interface.json \"" + filepath + "\" \"" + gclPath + "\"";
@@ -1151,7 +1158,7 @@ namespace Loader
             std::ifstream infile(filepath, std::ios::binary | std::ios::in);
             if(!infile.is_open())
             {
-                fprintf(stderr, "\nLoader::uploadDirect() : failed to compile '%s'\n", filename.c_str());
+                fprintf(stderr, "\nLoader::uploadDirect() : failed to compile '%s'\n", filepath.c_str());
                 filename = "";
                 if(gt1FileDeleted == 0) Editor::browseDirectory();
             }
@@ -1457,7 +1464,7 @@ namespace Loader
                 }
                 else
                 {
-                    filename = Editor::getBrowserPath() + _launchName;
+                    filename = _launchName;
                 }
 
                 uploadDirect(_uploadTarget, filename);

--- a/Contrib/at67/loader.h
+++ b/Contrib/at67/loader.h
@@ -75,7 +75,7 @@ namespace Loader
 
     UploadTarget getUploadTarget(void);
     void setUploadTarget(UploadTarget target);
-    void uploadDirect(UploadTarget uploadTarget, const std::string& name, const std::string path);
+    void uploadDirect(UploadTarget uploadTarget, const std::string& name);
 
     int getConfigRomsSize(void);
     ConfigRom* getConfigRom(int index);

--- a/Contrib/at67/loader.h
+++ b/Contrib/at67/loader.h
@@ -45,7 +45,6 @@ namespace Loader
     bool saveGt1File(const std::string& filepath, Gt1File& gt1File, std::string& filename);
     uint16_t printGt1Stats(const std::string& filename, const Gt1File& gt1File);
 
-
 #ifndef STAND_ALONE
     enum Endianness {Little, Big};
     enum UploadTarget {None, Emulator, Hardware};
@@ -69,11 +68,14 @@ namespace Loader
     };
 
 
+    std::string& getLaunchName(void);
     std::string& getCurrentGame(void);
+    void setLaunchName(const std::string& launchName);
     void setCurrentGame(const std::string& currentGame);
 
     UploadTarget getUploadTarget(void);
     void setUploadTarget(UploadTarget target);
+    void uploadDirect(UploadTarget uploadTarget, const std::string& name, const std::string path);
 
     int getConfigRomsSize(void);
     ConfigRom* getConfigRom(int index);

--- a/Contrib/at67/main.cpp
+++ b/Contrib/at67/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char* argv[])
     if(argc != 1  &&  argc != 2)
     {
         fprintf(stderr, "%s\n", VERSION_STR);
-        fprintf(stderr, "Usage:   gtemuAT67 <optional input filename> \n");
+        fprintf(stderr, "Usage:   gtemuAT67 <optional input filename>\n");
         return 1;
     }
 
@@ -58,24 +58,18 @@ int main(int argc, char* argv[])
     if(argc == 2)
     {
         std::string name = std::string(argv[1]);
-        size_t colon = name.find_last_of(":");
         size_t slash = name.find_last_of("\\/");
         size_t ram64k = name.find_last_of("64");
-
         std::string path = (slash != std::string::npos) ? name.substr(0, slash) : ".";
+        Expression::replaceText(path, "\\", "/");
         name = (slash != std::string::npos) ? name.substr(slash + 1) : name;
-        std::string fullpath = path + "/" + name;
 
 #ifdef _WIN32
-        // Windows...
-        if(colon != std::string::npos) fullpath = name;
         Cpu::enableWin32ConsoleSaveFile(false);
 #endif
 
-        //fprintf(stderr, "%s : %s : %s\n", path.c_str(), name.c_str(), fullpath.c_str());
-
         Assembler::setIncludePath(path);
-        Loader::setLaunchName(fullpath);
+        Loader::setLaunchName(path + "/" + name);
         Loader::setUploadTarget(Loader::Emulator);
         if(ram64k != std::string::npos) Cpu::swapMemoryModel();
     }

--- a/Contrib/at67/main.cpp
+++ b/Contrib/at67/main.cpp
@@ -30,8 +30,12 @@
 
 int main(int argc, char* argv[])
 {
-    UNREFERENCED_PARAM(argc);
-    UNREFERENCED_PARAM(argv);
+    if(argc != 1  &&  argc != 2)
+    {
+        fprintf(stderr, "%s\n", VERSION_STR);
+        fprintf(stderr, "Usage:   gtemuAT67 <optional input filename> \n");
+        return 1;
+    }
 
     Memory::initialise();
     Loader::initialise();
@@ -49,6 +53,32 @@ int main(int argc, char* argv[])
     Optimiser::initialise();
     Validater::initialise();
     Linker::initialise();
+
+    // Load file
+    if(argc == 2)
+    {
+        std::string name = std::string(argv[1]);
+        size_t colon = name.find_last_of(":");
+        size_t slash = name.find_last_of("\\/");
+        size_t ram64k = name.find_last_of("64");
+
+        std::string path = (slash != std::string::npos) ? name.substr(0, slash) : ".";
+        name = (slash != std::string::npos) ? name.substr(slash + 1) : name;
+        std::string fullpath = path + "/" + name;
+
+#ifdef _WIN32
+        // Windows...
+        if(colon != std::string::npos) fullpath = name;
+        Cpu::enableWin32ConsoleSaveFile(false);
+#endif
+
+        //fprintf(stderr, "%s : %s : %s\n", path.c_str(), name.c_str(), fullpath.c_str());
+
+        Assembler::setIncludePath(path);
+        Loader::setLaunchName(fullpath);
+        Loader::setUploadTarget(Loader::Emulator);
+        if(ram64k != std::string::npos) Cpu::swapMemoryModel();
+    }
 
 #if 0
     Image::TgaFile tgaFile;


### PR DESCRIPTION
Latest version of gtemuAT67 lets you launch .gcl, .gbas, .gasm and .gt1 from the command line:

e.g.  gtemuat67 gbas/Parallax.gbas

This also allows you to use file association in Windows and Linux to launch the emulator when clicking on those file types.

Windows:
- Right click on the file.
- Open With -> Choose another App -> More Apps
- Browse to wherever you built gtemuAT67.exe

Linux:
- sudo nano /usr/share/applications/gtemuAT67.desktop
- Add the following text:
[Desktop Entry]
Encoding=UTF-8
Name=Gigatron Emulator
Comment=Gigatron TTL EMulation
Exec=./gigatron-rom/Contrib/at67/gtemuAT67 %u
Terminal=true
Type=Application
Icon=
Categories=Application;Utility;
StartupNotify=true
MimeType=text/plain;
NoDisplay=true
