### PR TITLE
Ver 0.8.23

### DIFF
--- a/Contrib/at67/audio.cpp
+++ b/Contrib/at67/audio.cpp
@@ -127,10 +127,12 @@ namespace Audio
 
     void initialiseChannels(bool coldBoot, Cpu::RomType romType)
     {
+        UNREFERENCED_PARAM(romType);
+
         static uint8_t waveTables[256];
 
-        // ROM's V1 to V3 do not re-initialise RAM Audio Wave Tables on soft reboot
-        if(romType > Cpu::ROMERR  &&  romType < Cpu::ROMv4)
+        // ROM's V1 to V3 do not re-initialise RAM Audio Wave Tables on soft reboot, (we re-initialise them for ALL ROM versions)
+        //if(romType > Cpu::ROMERR  &&  romType < Cpu::ROMv4)
         {
             // Save Audio Wave Tables on cold reboot
             if(coldBoot)

--- a/Contrib/at67/compiler.cpp
+++ b/Contrib/at67/compiler.cpp
@@ -826,7 +826,7 @@ namespace Compiler
         // Discarded labels are replaced correctly later in outputLabels()
         if(_nextInternalLabel.size()  &&  internalLabel.size()) _discardedLabels.push_back({_vasmPC, internalLabel});
 
-        _codeLines[codeLineIdx]._vasm.push_back({uint16_t(_vasmPC - vasmSize), opcodeStr, line, label, pageJump, vasmSize});
+        _codeLines[codeLineIdx]._vasm.push_back({uint16_t(_vasmPC - vasmSize), opcodeStr, operandStr, line, label, pageJump, vasmSize});
         _codeLines[codeLineIdx]._vasmSize += vasmSize;
 
         if(nextTempVar) getNextTempVar();

--- a/Contrib/at67/compiler.h
+++ b/Contrib/at67/compiler.h
@@ -95,6 +95,7 @@ namespace Compiler
     {
         uint16_t _address;
         std::string _opcode;
+        std::string _operand;
         std::string _code;
         std::string _internalLabel;
         bool _pageJump = false;

--- a/Contrib/at67/cpu.cpp
+++ b/Contrib/at67/cpu.cpp
@@ -351,6 +351,11 @@ namespace Cpu
         _RAM[(address+1) & (Memory::getSizeRAM()-1)] = uint8_t(HI_BYTE(data));
     }
 
+    void setSizeRAM(size_t size)
+    {
+        _RAM.resize(size);
+    }
+
     void clearUserRAM(void)
     {
         // Not great for the Gigatron's RNG, will statistically bias it's results
@@ -378,7 +383,34 @@ namespace Cpu
         if(!_checkRomType) return;
         _checkRomType = false;
 
-        uint8_t romType = getRAM(ROM_TYPE) & ROM_TYPE_MASK;
+        uint8_t romType = ROMERR;
+#if 1
+        // This is the correct way to do it
+        romType = getRAM(ROM_TYPE) & ROM_TYPE_MASK;
+#else
+        // Directly read from hard coded addresses in ROM, because RAM can be corrupted in emulation mode and resets to 
+        // correct the corruption are not guaranteed, (unlike real hardware)
+        if(getROM(0x009A, 1) == 0x1C)
+        {
+            romType = ROMv1;
+        }
+        else if(getROM(0x0098, 1) == 0x20)
+        {
+            romType = ROMv2;
+        }
+        else if(getROM(0x0098, 1) == 0x28)
+        {
+            romType = ROMv3;
+        }
+        else if(getROM(0x007E, 1) == 0x38)
+        {
+            romType = ROMv4;
+        }
+        else if(getROM(0x005E, 1) == 0xF8)
+        {
+            romType = DEVROM;
+        }
+#endif
         switch((RomType)romType)
         {
             case ROMv1:

--- a/Contrib/at67/cpu.h
+++ b/Contrib/at67/cpu.h
@@ -134,6 +134,7 @@ namespace Cpu
     void setRAM16(uint16_t address, uint16_t data);
     void setROM16(uint16_t base, uint16_t address, uint16_t data);
     void setRomType(void);
+    void setSizeRAM(size_t size);
 
     void saveScanlineModes(void);
     void restoreScanlineModes(void);

--- a/Contrib/at67/keywords.cpp
+++ b/Contrib/at67/keywords.cpp
@@ -1219,18 +1219,18 @@ namespace Keywords
 
         // Parse labels
         std::vector<size_t> gOffsets;
-        std::vector<std::string> gotoTokens = Expression::tokenise(codeLine._code.substr(gOffset + gSize), ',', gOffsets, false);
-        if(gotoTokens.size() < 1)
+        std::vector<std::string> gTokens = Expression::tokenise(codeLine._code.substr(gOffset + gSize), ',', gOffsets, false);
+        if(gTokens.size() < 1)
         {
-            fprintf(stderr, "Keywords::keywordON() : Syntax error, must have at least one label after GOTO, in '%s' on line %d\n", codeLine._text.c_str(), codeLineIndex);
+            fprintf(stderr, "Keywords::keywordON() : Syntax error, must have at least one label after GOTO/GOSUB, in '%s' on line %d\n", codeLine._text.c_str(), codeLineIndex);
             return false;
         }
 
-        // Create label LUT
+        // Create on goto/gosub label LUT
         Compiler::getCodeLines()[codeLineIndex]._onGotoGosubLut._lut.clear();
-        for(int i=0; i<int(gotoTokens.size()); i++)
+        for(int i=0; i<int(gTokens.size()); i++)
         {
-            std::string gotoLabel = gotoTokens[i];
+            std::string gotoLabel = gTokens[i];
             Expression::stripWhitespace(gotoLabel);
             int labelIndex = Compiler::findLabel(gotoLabel);
             if(labelIndex == -1)
@@ -1248,7 +1248,7 @@ namespace Keywords
         }
 
         // Allocate giga memory for LUT
-        int size = int(gotoTokens.size()) * 2;
+        int size = int(gTokens.size()) * 2;
         uint16_t address;
         if(!Memory::getFreeRAM(Memory::FitDescending, size, 0x0200, Compiler::getRuntimeStart(), address))
         {

--- a/Contrib/at67/loader.h
+++ b/Contrib/at67/loader.h
@@ -17,6 +17,7 @@
 
 #define ZERO_CONST_ADDRESS        0x00
 #define ONE_CONST_ADDRESS         0x80
+#define CHANNEL_MASK              0x21
 
 #define LOADER_CONFIG_INI  "loader_config.ini"
 #define HIGH_SCORES_INI    "high_scores.ini"

--- a/Contrib/at67/loader_config.ini
+++ b/Contrib/at67/loader_config.ini
@@ -1,7 +1,7 @@
 [Comms]                ; case sensitive
 BaudRate    = 115200   ; arduino software stack doesn't like > 115200
 ComPort     = 0        ; can be an index or a name, eg: ComPort = 0 or ComPort = COM5
-TimeOut     = 5.0      ; maximum seconds to wait for Gigatron to respond
+TimeOut     = 6.0      ; maximum seconds to wait for Gigatron to respond
 GclBuild    = /home/ubu/gigatron-rom ; must be an absolute path, can contain spaces
 
 ; an example of how to use external ROMS, (no limit until out of memory)
@@ -10,3 +10,6 @@ RomName0    = ROMv3y.rom
 RomType0    = 0x28
 ;RomName1    = dev.rom
 ;RomType1    = 0xf8
+
+[RAM]
+AutoSet64k  = 1        ; enables/disables automatic switching of emulation memory model to 64k RAM

--- a/Contrib/at67/main.cpp
+++ b/Contrib/at67/main.cpp
@@ -59,7 +59,6 @@ int main(int argc, char* argv[])
     {
         std::string name = std::string(argv[1]);
         size_t slash = name.find_last_of("\\/");
-        size_t ram64k = name.find("64k");
         std::string path = (slash != std::string::npos) ? name.substr(0, slash) : ".";
         Expression::replaceText(path, "\\", "/");
         name = (slash != std::string::npos) ? name.substr(slash + 1) : name;
@@ -71,7 +70,17 @@ int main(int argc, char* argv[])
         Assembler::setIncludePath(path);
         Loader::setFilePath(path + "/" + name);
         Loader::setUploadTarget(Loader::Emulator);
-        if(ram64k != std::string::npos) Cpu::swapMemoryModel();
+
+        // Choose memory model
+        if(name.find("64k") != std::string::npos  ||  name.find("64K") != std::string::npos)
+        {
+            if(Memory::getSizeRAM() == RAM_SIZE_LO)
+            {
+                Memory::setSizeRAM(RAM_SIZE_HI);
+                Memory::initialise();
+                Cpu::setSizeRAM(Memory::getSizeRAM());
+            }
+        }
     }
 
 #if 0

--- a/Contrib/at67/optimiser.cpp
+++ b/Contrib/at67/optimiser.cpp
@@ -325,16 +325,12 @@ RESTART_OPTIMISE:
                         // First operand
                         int firstIndex = matchSequences[j]._firstIndex;
                         int firstLine = vasmIndex + firstIndex;
-                        size_t firstSpace = Compiler::getCodeLines()[i]._vasm[firstLine]._code.find_first_of("  \n\r\f\t\v");
-                        std::string firstOperand = Compiler::getCodeLines()[i]._vasm[firstLine]._code.substr(firstSpace);
-                        Expression::stripWhitespace(firstOperand);
+                        std::string firstOperand = Compiler::getCodeLines()[i]._vasm[firstLine]._operand;
 
                         // Second operand
                         int secondIndex = matchSequences[j]._secondIndex;
                         int secondLine = vasmIndex + secondIndex;
-                        size_t secondSpace = Compiler::getCodeLines()[i]._vasm[secondLine]._code.find_first_of("  \n\r\f\t\v");
-                        std::string secondOperand = Compiler::getCodeLines()[i]._vasm[secondLine]._code.substr(secondSpace);
-                        Expression::stripWhitespace(secondOperand);
+                        std::string secondOperand = Compiler::getCodeLines()[i]._vasm[secondLine]._operand;
 
 /*************************************************************************************************************************************************************/
 /* Opcode matches required, operand matches required                                                                                                         */
@@ -412,9 +408,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // ADDW's operand becomes the LDI's operand
-                                    size_t ldiSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldiOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldiSpace);
-                                    Expression::stripWhitespace(ldiOperand);
+                                    std::string ldiOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = "ADDI" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldiOperand;
 
                                     // Delete STW and LDW
@@ -434,9 +428,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // ADDW's operand becomes the LDW's operand
-                                    size_t ldwSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldwSpace);
-                                    Expression::stripWhitespace(ldwOperand);
+                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = matchSequences[j]._sequence[2] + ldwOperand.substr(2); // don't need the leading "0x"
 
                                     // Delete STW and LDW
@@ -456,9 +448,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // ADDW's operand becomes the LDW's operand
-                                    size_t ldwSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldwSpace);
-                                    Expression::stripWhitespace(ldwOperand);
+                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldwOperand;
 
                                     // Delete STW and LDW
@@ -478,9 +468,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // ANDW's operand becomes the LDI's operand
-                                    size_t ldiSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldiOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldiSpace);
-                                    Expression::stripWhitespace(ldiOperand);
+                                    std::string ldiOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = "ANDI" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldiOperand;
 
                                     // Delete STW and LDW
@@ -500,9 +488,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // ANDW's operand becomes the LDW's operand
-                                    size_t ldwSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldwSpace);
-                                    Expression::stripWhitespace(ldwOperand);
+                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = matchSequences[j]._sequence[2] + ldwOperand.substr(2); // don't need the leading "0x"
 
                                     // Delete STW and LDW
@@ -522,9 +508,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // ANDW's operand becomes the LDW's operand
-                                    size_t ldwSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldwSpace);
-                                    Expression::stripWhitespace(ldwOperand);
+                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = "ANDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldwOperand;
 
                                     // Delete STW and LDW
@@ -544,9 +528,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // XORW's operand becomes the LDI's operand
-                                    size_t ldiSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldiOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldiSpace);
-                                    Expression::stripWhitespace(ldiOperand);
+                                    std::string ldiOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = "XORI" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldiOperand;
 
                                     // Delete STW and LDW
@@ -566,9 +548,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // XORW's operand becomes the LDW's operand
-                                    size_t ldwSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldwSpace);
-                                    Expression::stripWhitespace(ldwOperand);
+                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = matchSequences[j]._sequence[2] + ldwOperand.substr(2); // don't need the leading "0x"
 
                                     // Delete STW and LDW
@@ -588,9 +568,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // XORW's operand becomes the LDW's operand
-                                    size_t ldwSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldwSpace);
-                                    Expression::stripWhitespace(ldwOperand);
+                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = "XORW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldwOperand;
 
                                     // Delete STW and LDW
@@ -610,9 +588,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // ORW's operand becomes the LDI's operand
-                                    size_t ldiSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldiOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldiSpace);
-                                    Expression::stripWhitespace(ldiOperand);
+                                    std::string ldiOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = "ORI" + std::string(OPCODE_TRUNC_SIZE - 3, ' ') + ldiOperand;
 
                                     // Delete STW and LDW
@@ -632,9 +608,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // ORW's operand becomes the LDW's operand
-                                    size_t ldwSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldwSpace);
-                                    Expression::stripWhitespace(ldwOperand);
+                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = matchSequences[j]._sequence[2] + ldwOperand.substr(2); // don't need the leading "0x"
 
                                     // Delete STW and LDW
@@ -654,9 +628,7 @@ RESTART_OPTIMISE:
                                     if(!migrateInternalLabel(i, firstLine + 1, firstLine + 2)) break;
 
                                     // ORW's operand becomes LDW's operand
-                                    size_t ldwSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._code.substr(ldwSpace);
-                                    Expression::stripWhitespace(ldwOperand);
+                                    std::string ldwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 1]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine + 2]._code = "ORW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldwOperand;
 
                                     // Delete STW LDW
@@ -687,9 +659,7 @@ RESTART_OPTIMISE:
                                 case Lsl8Var:
                                 {
                                     // ST's operand becomes STW's operand
-                                    size_t stwSpace = Compiler::getCodeLines()[i]._vasm[firstLine + 3]._code.find_first_of("  \n\r\f\t\v");
-                                    std::string stwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 3]._code.substr(stwSpace);
-                                    Expression::stripWhitespace(stwOperand);
+                                    std::string stwOperand = Compiler::getCodeLines()[i]._vasm[firstLine + 3]._operand;
                                     Compiler::getCodeLines()[i]._vasm[firstLine]._code = "ST" + std::string(OPCODE_TRUNC_SIZE - 2, ' ') + stwOperand + " + 1";
 
                                     // Delete LDW ANDW STW
@@ -737,18 +707,13 @@ RESTART_OPTIMISE:
                                 // Migrate it's label if it has one
                                 if(!migrateInternalLabel(i, firstLine - 1, firstLine + 1)) break;
 
-                                // Get saved LDW's operand
-                                size_t ldwSpace = savedLDW._code.find_first_of("  \n\r\f\t\v");
-                                std::string ldwOperand = savedLDW._code.substr(ldwSpace);
-                                Expression::stripWhitespace(ldwOperand);
-
                                 // Delete previous line LDW and first STW
                                 linesDeleted = true;
                                 itVasm = Compiler::getCodeLines()[i]._vasm.erase(Compiler::getCodeLines()[i]._vasm.begin() + firstLine - 1);
                                 itVasm = Compiler::getCodeLines()[i]._vasm.erase(itVasm);
 
                                 // Replace operand of ADDW
-                                (itVasm + 1)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldwOperand;
+                                (itVasm + 1)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + savedLDW._operand;
                                 adjustLabelAddresses(i, firstLine - 1, -4);
                                 adjustVasmAddresses(i, firstLine - 1, -4);
                             }
@@ -764,19 +729,14 @@ RESTART_OPTIMISE:
                                 // Migrate it's label if it has one
                                 if(!migrateInternalLabel(i, firstLine - 1, firstLine + 1)) break;
 
-                                // Get saved LDW's operand
-                                size_t ldwSpace = savedLDW._code.find_first_of("  \n\r\f\t\v");
-                                std::string ldwOperand = savedLDW._code.substr(ldwSpace);
-                                Expression::stripWhitespace(ldwOperand);
-
                                 // Delete previous line LDW and first STW
                                 linesDeleted = true;
                                 itVasm = Compiler::getCodeLines()[i]._vasm.erase(Compiler::getCodeLines()[i]._vasm.begin() + firstLine - 1);
                                 itVasm = Compiler::getCodeLines()[i]._vasm.erase(itVasm);
 
                                 // Replace operand of both ADDW's
-                                (itVasm + 1)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldwOperand;
-                                (itVasm + 2)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldwOperand;
+                                (itVasm + 1)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + savedLDW._operand;
+                                (itVasm + 2)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + savedLDW._operand;
                                 adjustLabelAddresses(i, firstLine - 1, -4);
                                 adjustVasmAddresses(i, firstLine - 1, -4);
                             }
@@ -841,18 +801,13 @@ RESTART_OPTIMISE:
                                 // Now optimise the first LDW and second STW for second phase
                                 Compiler::VasmLine savedLDW = Compiler::getCodeLines()[i]._vasm[firstLine];
 
-                                // Get saved LDW's operand
-                                size_t ldwSpace = savedLDW._code.find_first_of("  \n\r\f\t\v");
-                                std::string ldwOperand = savedLDW._code.substr(ldwSpace);
-                                Expression::stripWhitespace(ldwOperand);
-
                                 // Delete first LDW and second STW
                                 linesDeleted = true;
                                 itVasm = Compiler::getCodeLines()[i]._vasm.erase(Compiler::getCodeLines()[i]._vasm.begin() + firstLine);
                                 itVasm = Compiler::getCodeLines()[i]._vasm.erase(itVasm);
 
                                 // Replace operand of ADDW
-                                (itVasm + 1)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldwOperand;
+                                (itVasm + 1)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + savedLDW._operand;
                                 adjustLabelAddresses(i, firstLine, -4);
                                 adjustVasmAddresses(i, firstLine, -4);
                             }
@@ -891,19 +846,14 @@ RESTART_OPTIMISE:
                                 // Now optimise the first LDW and second STW for second phase
                                 Compiler::VasmLine savedLDW = Compiler::getCodeLines()[i]._vasm[firstLine];
 
-                                // Get saved LDW's operand
-                                size_t ldwSpace = savedLDW._code.find_first_of("  \n\r\f\t\v");
-                                std::string ldwOperand = savedLDW._code.substr(ldwSpace);
-                                Expression::stripWhitespace(ldwOperand);
-
                                 // Delete first LDW and second STW
                                 linesDeleted = true;
                                 itVasm = Compiler::getCodeLines()[i]._vasm.erase(Compiler::getCodeLines()[i]._vasm.begin() + firstLine);
                                 itVasm = Compiler::getCodeLines()[i]._vasm.erase(itVasm);
 
                                 // Replace operand of both ADDW's
-                                (itVasm + 1)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldwOperand;
-                                (itVasm + 2)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + ldwOperand;
+                                (itVasm + 1)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + savedLDW._operand;
+                                (itVasm + 2)->_code = "ADDW" + std::string(OPCODE_TRUNC_SIZE - 4, ' ') + savedLDW._operand;
                                 adjustLabelAddresses(i, firstLine, -4);
                                 adjustVasmAddresses(i, firstLine, -4);
                             }
@@ -919,14 +869,10 @@ RESTART_OPTIMISE:
 
                                 // Add operands together, replace first operand, delete 2nd opcode and operand
                                 Compiler::VasmLine vasm = Compiler::getCodeLines()[i]._vasm[firstLine];
-                                size_t space = vasm._code.find_first_of("  \n\r\f\t\v");
-                                std::string operand = vasm._code.substr(space);
-                                Expression::stripWhitespace(operand);
+                                std::string operand = vasm._operand;
                                 Expression::stringToU8(operand, addi0);
                                 vasm = Compiler::getCodeLines()[i]._vasm[firstLine + 1];
-                                space = vasm._code.find_first_of("  \n\r\f\t\v");
-                                operand = vasm._code.substr(space);
-                                Expression::stripWhitespace(operand);
+                                operand = vasm._operand;
                                 Expression::stringToU8(operand, addi1);
                                 int result = addi0 + addi1;
                                 if(result > 255) break; // result to large for an ADDI operand so exit

--- a/Contrib/at67/validater.cpp
+++ b/Contrib/at67/validater.cpp
@@ -55,7 +55,7 @@ namespace Validater
     }
 
     auto insertPageJumpInstruction(const std::vector<Compiler::CodeLine>::iterator& itCode, const std::vector<Compiler::VasmLine>::iterator& itVasm,
-                                   const std::string& opcode, const std::string& code, uint16_t address, int vasmSize)
+                                   const std::string& opcode, const std::string& operand, const std::string& code, uint16_t address, int vasmSize)
     {
         if(itVasm >= itCode->_vasm.end())
         {
@@ -65,7 +65,7 @@ namespace Validater
 
         Memory::takeFreeRAM(address, vasmSize, true);
 
-        return itCode->_vasm.insert(itVasm, {address, opcode, code, "", true, vasmSize});
+        return itCode->_vasm.insert(itVasm, {address, opcode, operand, code, "", true, vasmSize});
     }
 
     // TODO: make this more flexible, (e.g. sound channels off etc)
@@ -163,7 +163,7 @@ namespace Validater
                         // CALLI PAGE JUMP
                         std::string codeCALLI;
                         int sizeCALLI = Compiler::createVcpuAsm("CALLI", nextPClabel, codeLineIndex, codeCALLI);
-                        itVasm = insertPageJumpInstruction(itCode, itVasm, "CALLI",  codeCALLI,  uint16_t(currPC), sizeCALLI);
+                        itVasm = insertPageJumpInstruction(itCode, itVasm, "CALLI", nextPClabel, codeCALLI,  uint16_t(currPC), sizeCALLI);
                     }
                     else
                     {
@@ -173,10 +173,10 @@ namespace Validater
                         int sizeLDWI = Compiler::createVcpuAsm("LDWI", nextPClabel, codeLineIndex, codeLDWI);
                         int sizeCALL = Compiler::createVcpuAsm("CALL", "giga_vAC", codeLineIndex, codeCALL);
                         int sizeLDW  = Compiler::createVcpuAsm("LDW", Expression::byteToHexString(VAC_SAVE_START), codeLineIndex, codeLDW);
-                        itVasm = insertPageJumpInstruction(itCode, itVasm + 0, "STW",  codeSTW,  uint16_t(currPC),                      sizeSTW);
-                        itVasm = insertPageJumpInstruction(itCode, itVasm + 1, "LDWI", codeLDWI, uint16_t(currPC + sizeSTW),            sizeLDWI);
-                        itVasm = insertPageJumpInstruction(itCode, itVasm + 1, "CALL", codeCALL, uint16_t(currPC + sizeSTW + sizeLDWI), sizeCALL);
-                        itVasm = insertPageJumpInstruction(itCode, itVasm + 1, "LDW",  codeLDW,  uint16_t(nextPC),                      sizeLDW);
+                        itVasm = insertPageJumpInstruction(itCode, itVasm + 0, "STW",  Expression::byteToHexString(VAC_SAVE_START), codeSTW,  uint16_t(currPC), sizeSTW);
+                        itVasm = insertPageJumpInstruction(itCode, itVasm + 1, "LDWI", nextPClabel, codeLDWI, uint16_t(currPC + sizeSTW), sizeLDWI);
+                        itVasm = insertPageJumpInstruction(itCode, itVasm + 1, "CALL", "giga_vAC", codeCALL, uint16_t(currPC + sizeSTW + sizeLDWI), sizeCALL);
+                        itVasm = insertPageJumpInstruction(itCode, itVasm + 1, "LDW",  Expression::byteToHexString(VAC_SAVE_START), codeLDW,  uint16_t(nextPC), sizeLDW);
 
                         // New page address is offset by size of vAC restore
                         restoreOffset = sizeLDW;


### PR DESCRIPTION
- Added auto configuration of 64K RAM for the emulator when loading 64K *.gbas, *.gasm, *.gcl and *.gt1 files, (configurable in "loader_config.ini").
- Added code to reset the audio channel mask when loading files into the emulator.
- Refactored operand handling within the BASIC compiler's optimiser.