### PR TITLE
Ignore garbage data when reading chars

### DIFF
--- a/Utils/sendFile.py
+++ b/Utils/sendFile.py
@@ -96,17 +96,20 @@ def waitReply(expectPrompt=True):
 
 def readLine():
   """Read line from serial port with optional verbosity"""
-  line = ser.readline()
-  if line:
-    line = line.decode()        # Convert from bytes to Unicode
-    line = line.rstrip()        # Remove any trailing newline and spaces
-    log('<', line)
-  else:
-    line = None                 # Signal that there is a timeout
-    if args.verbose:
-      sys.stdout.write('.')
-      sys.stdout.flush()
-  return line
+  try:
+    line = ser.readline()
+    if line:
+      line = line.decode()        # Convert from bytes to Unicode
+      line = line.rstrip()        # Remove any trailing newline and spaces
+      log('<', line)
+    else:
+      line = None                 # Signal that there is a timeout
+      if args.verbose:
+        sys.stdout.write('.')
+        sys.stdout.flush()
+    return line
+  except UnicodeDecodeError:
+    return readLine()
 
 def sendGt1(fp):
   """Send Gigatron object file"""


### PR DESCRIPTION
I'm getting garbage data when using sendFile.py on my MacBook plus Arduino Uno. Ignoring the garbage by catching the exception allowed me to use the script as intended.

I'm not sure if this is the appropriate way to fix this issue, or if it is specific to my environment, so I've popped it here to open the discussion.

If there's other options to explore, let me know 😊