### PR TITLE
Small changes to modules in Core/ to support programs other than the main ROMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 /Contrib/at67/tools/gtmakerom/gtmakerom
 /Contrib/at67/tools/gtsplitrom/gtsplitrom
 .DS_Store
+__pycache__/

--- a/Core/gcl0x.py
+++ b/Core/gcl0x.py
@@ -8,6 +8,7 @@
 from asm import *
 import string
 import sys
+from pathlib import Path
 
 class Program:
   def __init__(self, name, forRom=True):
@@ -30,7 +31,11 @@ class Program:
     self.execute = None
     self.needPatch = False
     self.lengths = {} # block -> length, or var -> length
-    loadBindings('Core/v6502.json') # XXX Provisional method to load mnemonics
+    # XXX Provisional method to load mnemonics
+    try:
+      loadBindings(Path('Core') / 'v6502.json')
+    except FileNotFoundError:
+      loadBindings(Path(__file__).parent / 'v6502.json')
 
   def org(self, address):
     """Set start address"""


### PR DESCRIPTION
In general, the files in Core/ expect to be used directly from the \*rom\*.asm.py scripts in the repository root directory. Building different things, working under Contrib/, and running code differently (such as in unit tests), can violate some of those assumptions.

Hopefully these changes are fairly uncontroversial. I'm trying to fix bugs rather than rebuild the tooling (at this stage anyway!) I've pulled them onto a different branch, and made them a separate PR from my other work, so that they can be properly reviewed.

I think I might have a few more similar changes to come.