### PR TITLE
Updated glcc to GLCC_RELEASE_1.5-7-gd519d8b

### DIFF
--- a/Compilers/glcc/gigatron/glccver.py
+++ b/Compilers/glcc/gigatron/glccver.py
@@ -1,1 +1,1 @@
-ver="GLCC_RELEASE_1.5"
+ver="GLCC_RELEASE_1.5-7-gd519d8b"

--- a/Compilers/glcc/gigatron/libc/_filbuf.c
+++ b/Compilers/glcc/gigatron/libc/_filbuf.c
@@ -2,7 +2,6 @@
 #include <errno.h>
 
 /* This is the generic version of fp->_vec->filbuf.
-   It is similar to cons_filbuf but:
    - can use arbitrary buffer or arbitrary size.
    - can allocate a buffer when none is provided,
      but only if malloc is otherwise linked.

--- a/Compilers/glcc/gigatron/libc/_flsbuf.c
+++ b/Compilers/glcc/gigatron/libc/_flsbuf.c
@@ -1,11 +1,17 @@
 #include "_stdio.h"
 #include <errno.h>
 
+#ifdef WITH_LINEBUFFERING
+# define HAS_BUF(flag) (flag & _IOFBF))
+#else
+# define HAS_BUF(flag) (!(flag & _IONBF))
+#endif
+
 /* This is the generic version of fp->_v->filbuf.
-   It is similar to cons_flsbuf but:
    - can use arbitrary buffer or arbitrary size.
    - can allocate a buffer when none is provided,
      but only if malloc is otherwise referenced.
+   - optionally handles line buffering.
    - checks for errors and end-of-file condition. */
 
 int _default_flsbuf(register int c, register FILE *fp)
@@ -14,9 +20,9 @@ int _default_flsbuf(register int c, register FILE *fp)
 	register int cnt = 0;
 	register int n = 0;
 	register char *buf;
-	
-	/* Ensure buffer */
-	if ((flag & _IOFBF) && !fp->_base) {
+
+	/* Allocate buffer */
+	if (HAS_BUF(flag) && !fp->_base) {
 		struct _sbuf *sb = 0;
 		if (__glink_weak_malloc)
 			sb = __glink_weak_malloc(BUFSIZ);
@@ -27,20 +33,32 @@ int _default_flsbuf(register int c, register FILE *fp)
 			flag = (flag & ~_IOBUFMASK) | _IONBF;
 		fp->_flag = flag;
 	}
-	/* Determine buffer */
-	if (flag & _IOFBF) {
+	/* Locate buffer */
+	if (HAS_BUF(flag)) {
 		cnt = fp->_base->size - 1;
 		buf = fp->_base->data;
 		if (fp->_ptr)
 			n = fp->_ptr - buf;
 	} else 
 		buf = fp->_buf;
-	/* Prepare buffer for future putc */ 
-	fp->_ptr = buf;
-	fp->_cnt = cnt;
-	/* Write current buffer + c */
+	/* Append c to buffer */
 	if (c >= 0)
 		buf[n++] = (char) c;
+	/* Line buffering */
+#if WITH_LINEBUFFERING
+	if ((flag & _IOLBF) == _IOLBF) {
+		if (c >= 0 && c != '\n' && c != '\r' && cnt - n > 0) {
+			fp->_ptr = buf + n;
+			fp->_cnt = 0;
+			return c;
+		}
+		cnt = 0;
+	}
+#endif
+	/* Set ptr and cnt for future putc */
+	fp->_ptr = buf;
+	fp->_cnt = cnt;
+	/* Write data */
 	while (n > 0) {
 		if ((cnt = fp->_v->write(fp, buf, n)) <= 0)
 			return _serror(fp, EIO);

--- a/Compilers/glcc/gigatron/libc/_fwrite.c
+++ b/Compilers/glcc/gigatron/libc/_fwrite.c
@@ -7,9 +7,6 @@ size_t _fwrite(register FILE *fp, register const char *buf, register size_t sz)
 		memcpy(fp->_ptr, buf, sz);
 		fp->_ptr += sz;
 		fp->_cnt -= sz;
-		if ((fp->_flag & _IOLBF) == _IOLBF)
-			if (memchr(buf, '\n', sz))
-				_fflush(fp);
 		return sz;
 	} else {
 		register int n;

--- a/Compilers/glcc/gigatron/libc/_iob_setup.c
+++ b/Compilers/glcc/gigatron/libc/_iob_setup.c
@@ -5,19 +5,14 @@
    is referenced in the program. The default version hooks stdin,
    stdout, and stderr to the console. */
 
-extern struct _sbuf _cons_ibuf;
-extern struct _sbuf _cons_obuf;
-
 void _iob_setup(void)
 {
 	/* stdin */
 	_iob[0]._flag = _IOLBF|_IOREAD;
-	_iob[0]._base = &_cons_ibuf;
 	_iob[0]._v = &_cons_svec;
 	_iob[0]._file = 0;
 	/* stdout */
 	_iob[1]._flag = _IOLBF|_IOWRIT;
-	_iob[1]._base = &_cons_obuf;
 	_iob[1]._v = &_cons_svec;
 	_iob[1]._file = 1;
 	/* stderr */

--- a/Compilers/glcc/gigatron/libc/cons_stdio.c
+++ b/Compilers/glcc/gigatron/libc/cons_stdio.c
@@ -12,42 +12,23 @@ struct _cbuf {
 	char data[CONS_BUFSIZE];
 };
 
-struct _cbuf _cons_ibuf = { CONS_BUFSIZE };
-struct _cbuf _cons_obuf = { CONS_BUFSIZE };
+static struct _cbuf _cons_ibuf = { CONS_BUFSIZE };
 
 static int cons_write(FILE *fp, register const void *buf, register size_t cnt)
 {
-	register int written = 0;
-	while (written != cnt) {
-		register int n;
-		if (! (n = console_print((char*)buf + written, cnt - written)))
-			n = 1;
-		written += n;
-	}
-	return written;
+	return console_print((char*)buf, cnt);
 }
 
 static int cons_flsbuf(register int c, register FILE *fp)
 {
-	register char *buf = _cons_obuf.data;
-	register int cnt = 0;
-	register int n = 0;
-	register char *p;
-	
-	if (fp->_flag & _IOFBF) {
-		cnt = CONS_BUFSIZE - 1;
-		if ((p = fp->_ptr))
-			n = p - buf;
-	}
-	fp->_base = (struct _sbuf*)&_cons_obuf;
-	fp->_ptr = buf;
-	fp->_cnt = cnt;
+	fp->_ptr = 0;
+	fp->_cnt = 0;
 	if (c >= 0) {
-		buf[n] = (char) c;
-		n += 1;
+		fp->_buf[0] = c;
+		console_print(fp->_buf, 1);
+		return c;
 	}
-	cons_write(fp, buf, n);
-	return c;
+	return 0;
 }
 
 static int cons_read(FILE *fp, register void *buf, size_t cnt)
@@ -60,13 +41,13 @@ static int cons_filbuf(register FILE *fp)
 {
 	register int n;
 	register char *buf = _cons_ibuf.data;
+	fp->_base = (struct _sbuf*)&_cons_ibuf;
 	if (fp == stdin)
 		_fflush(stdout);
 	if (fp->_flag & _IOFBF)
 		n = console_readline(buf, CONS_BUFSIZE);
 	else
 		n = cons_read(fp, buf, 1);
-	fp->_base = (struct _sbuf*)&_cons_ibuf;
 	fp->_cnt = n - 1;
 	fp->_ptr = buf + 1;
 	return buf[0];

--- a/Compilers/glcc/gigatron/libc/fopen.c
+++ b/Compilers/glcc/gigatron/libc/fopen.c
@@ -31,7 +31,7 @@ FILE *freopen(register const char *fname, register const char *mode, register FI
 	register int oflag, nflag;
 	if (! (oflag = nflag = fp->_flag))
 		nflag = _IOFBF;
-	nflag = _sflags(oflag, mode);
+	nflag = _sflags(nflag, mode);
 	if (! (nflag && fname)) {
 		errno = EINVAL;
 		return 0;

--- a/Compilers/glcc/gigatron/libc/fputc.c
+++ b/Compilers/glcc/gigatron/libc/fputc.c
@@ -2,8 +2,5 @@
 
 int fputc(register int c, register FILE *fp)
 {
-	c = putc(c, fp);
-	if (c == '\n' && (fp->_flag & _IOLBF) == _IOLBF)
-		_fflush(fp);
-	return c;
+	return putc(c, fp);
 }

--- a/Compilers/glcc/gigatron/libc/malloc.c
+++ b/Compilers/glcc/gigatron/libc/malloc.c
@@ -121,7 +121,7 @@ void free(register void *ptr)
 	register head_t *b;
 	register int size;	
 	if (ptr) {
-		size = __chk_block_header(b = (head_t*)((char*)ptr - 6)); 
+		size = __chk_block_header(b = (head_t*)((char*)ptr - 8));
 		if (! (b->size = size)) {
 #if DEBUG
 			malloc_map();
@@ -143,13 +143,13 @@ void *malloc(register size_t sz)
 	register head_t *b;
 	if (sz < 4)
 		sz = 4;
-	if ((sz = (((sz + 7) | 1) ^ 1)) < 0x8000u)
+	if ((sz = (((sz + 8 + 3) | 3) ^ 3)) < 0x8000u)
 		if (b = find_block(sz)) {
 #if DEBUG
 			printf("After malloc() sz=%d blk=%04x\n", sz, b);
 			malloc_map();
 #endif
-			return (char*)b + 6;
+			return (char*)b + 8;
 		}
 	return 0;
 }

--- a/Compilers/glcc/gigatron/libc/realloc.c
+++ b/Compilers/glcc/gigatron/libc/realloc.c
@@ -5,19 +5,18 @@ extern int __chk_block_header(void *);
 
 void *realloc(register void *ptr, register size_t nsz)
 {
-	register size_t osz;
 	register void *nptr;
-	
-	osz = 0;
-	if (ptr && !(osz = __chk_block_header((char*)ptr - 6) - 6))
+	register int osz = 0;
+	// check previous block.
+	// note that __chk_block_header returns int not uint
+	if (ptr && (osz = __chk_block_header((char*)ptr - 8) - 8) < 0)
 		return 0;
 	if (!(nptr = malloc(nsz)))
 		return 0;
-	if (osz < nsz)
+	if ((size_t)osz < nsz)
 		nsz = osz;
 	if (nsz)
 		memcpy(nptr, ptr, nsz);
-	if (ptr)
-		free(ptr);
+	free(ptr); // free(0) is ok.
 	return nptr;
 }

--- a/Compilers/glcc/gigatron/map32k/map.py
+++ b/Compilers/glcc/gigatron/map32k/map.py
@@ -34,6 +34,12 @@ def map_segments():
         for addr in range(tp[1], eaddr, estep):
             yield (addr, addr+tp[0], tp[4])
 
+def map_place(name):
+    '''
+    Returns a list of additional (PLACE...) directives for file 'name'.
+    '''
+    return []
+
 def map_libraries(romtype):
     '''
     Returns a list of extra libraries to scan before the standard ones

--- a/Compilers/glcc/gigatron/map512k/map.py
+++ b/Compilers/glcc/gigatron/map512k/map.py
@@ -42,6 +42,12 @@ def map_segments():
         for addr in range(tp[1], eaddr, estep):
             yield (addr, addr+tp[0], tp[4])
 
+def map_place(name):
+    '''
+    Returns a list of additional (PLACE...) directives for file 'name'.
+    '''
+    return []
+
 def map_libraries(romtype):
     '''
     Returns a list of extra libraries to scan before the standard ones

--- a/Compilers/glcc/gigatron/map64k/map.py
+++ b/Compilers/glcc/gigatron/map64k/map.py
@@ -43,6 +43,12 @@ def map_segments():
         for addr in range(tp[1], eaddr, estep):
             yield (addr, addr+tp[0], tp[4])
 
+def map_place(name):
+    '''
+    Returns a list of additional (PLACE...) directives for file 'name'.
+    '''
+    return []
+
 def map_libraries(romtype):
     '''
     Returns a list of extra libraries to scan before the standard ones

--- a/Compilers/glcc/gigatron/mapconx/map.py
+++ b/Compilers/glcc/gigatron/mapconx/map.py
@@ -39,6 +39,12 @@ def map_segments():
         for addr in range(tp[1], eaddr, estep):
             yield (addr, addr+tp[0], tp[4])
 
+def map_place(name):
+    '''
+    Returns a list of additional (PLACE...) directives for file 'name'.
+    '''
+    return []
+
 def map_libraries(romtype):
     '''
     Returns a list of extra libraries to scan before the standard ones

--- a/Compilers/glcc/stuff/fp/yofp0.c
+++ b/Compilers/glcc/stuff/fp/yofp0.c
@@ -2,6 +2,9 @@
 #include <stdio.h>
 #include <math.h>
 
+/* uncomment to bypass gtsim printf */
+/* #define printf(...) fprintf(stdout,__VA_ARGS__) /**/
+
 int main()
 {
 	const char *s = "pi";

--- a/Compilers/glcc/stuff/tst/TSTio.c
+++ b/Compilers/glcc/stuff/tst/TSTio.c
@@ -15,8 +15,18 @@ int main()
 			fputs("Read [", stdout);
 			putchar(isprint(c) ? c : '?');
 			fputs("]\n", stdout);
-			if (c == 'q')
+			if (c == 'U') {
+				fputs("Read unbuffered\n", stdout);
+				setvbuf(stdin, NULL, _IONBF, 0);
+			}
+			if (c == 'B') {
+				fputs("Read buffered\n", stdout);
+				setvbuf(stdin, NULL, _IOLBF, 0);
+			}
+			if (c == 'Q') {
+				fputs("Quitting\n", stdout);
 				break;
+			}
 			if (isdigit(c))
 				ungetc('#', stdin);
 			if (c == '0')


### PR DESCRIPTION
    Squashed 'Compilers/glcc/' changes from ece2c1a3..d519d8b7

    d519d8b7 fixed realloc after malloc aligment change
    d08314d0 Fix issue#3 (malloc aligns on 4 bytes boundaries)
    34cccffd stdio: simplify line buffering (disabled by macro)
    851185de simplified cons_stdio - stdout/err no longer buffers at all (no benefit). - stdin buffers with _cons_ibuf
    0e44bb3b realloc: more robust to incorrect oldptr.
    7f3daca4 stdio: fix initial buffering flag
    85d207cd Added 'map_place' map function that overlay file can use to generate placement directives.

    git-subtree-dir: Compilers/glcc
    git-subtree-split: d519d8b7e11e5cf33eaba35168be6a9d97ba0836