### PR TITLE
Fixed unified vRTI timing mismatch

### DIFF
--- a/Apps/TinyBASIC/TinyBASIC.gcl
+++ b/Apps/TinyBASIC/TinyBASIC.gcl
@@ -964,7 +964,7 @@ _Statements5=*                  {Borrow a few bytes here for RUN}
 { Calculate vAC * Value, result in vAC }
 [def
   _sysArgs0= 
-  \SYS_Multiply_s16_DEVROM_88 _sysFn=
+  \SYS_Multiply_s16_DEVROM_66 _sysFn=
   Value _sysArgs2=
   0 _sysArgs4= 
   _sysArgs6 tmp=

--- a/Core/dev.asm.py
+++ b/Core/dev.asm.py
@@ -2403,23 +2403,22 @@ label('vRTI#18')
 ld(-32//2-v6502_adjust)         #18
 adda([vTicks])                  #19
 bge('vRTI#22')                  #20
-st([vTmp])                      #21
-ld([vIrqSave+2])                #22
-st([vAC])                       #23
-ld([vIrqSave+3])                #24
-st([vAC+1])                     #25
-ld([vIrqSave+4])                #26
-st([vCpuSelect])                #27
-ld([vTicks])                    #0
+ld([vIrqSave+2])                #21
+st([vAC])                       #22
+ld([vIrqSave+3])                #23
+st([vAC+1])                     #24
+ld([vIrqSave+4])                #25
+st([vCpuSelect])                #26
+ld([vTicks])                    #27
+adda(maxTicks-28//2)            #28-28=0
 ld(hi('RESYNC'),Y)              #1
 jmp(Y,'RESYNC')                 #2
-adda(maxTicks-28//2)            #3
-
+nop()                           #3
 
 label('vRTI#22')
 ld(hi('vRTI#25'),Y)             #22
 jmp(Y,'vRTI#25')                #23
-ld([vIrqSave+2])                #24
+st([vAC])                       #24
 
 # vRTI entry point
 assert(pc()&255 == 251)         # The landing offset 251 for LUP trampoline is fixed
@@ -5230,13 +5229,13 @@ runVcpu(186-98-extra,           #98 Application cycles (scan line 0)
 
 # vRTI immediate resume
 label('vRTI#25')
-st([vAC])                       #25
-ld([vIrqSave+3])                #26
-st([vAC+1])                     #27
-ld([vIrqSave+4])                #28
-st([vCpuSelect],Y)              #29
+ld([vIrqSave+3])                #25
+st([vAC+1])                     #26
+ld([vIrqSave+4])                #27
+st([vCpuSelect],Y)              #28
+ld(-32//2)                      #29
 jmp(Y,'ENTER')                  #30
-ld([vTmp])                      #31-32=-1
+adda([vTicks])                  #31-32=-1
 
 
 # Entered last line of vertical blank (line 40)

--- a/Core/dev.asm.py
+++ b/Core/dev.asm.py
@@ -773,7 +773,7 @@ jmp(Y,'REENTER')                #16
 ld(-20/2)                       #17
 
 #-----------------------------------------------------------------------
-# Extension SYS_Multiply_s16_DEVROM_88: 16 bit multiplication
+# Extension SYS_Multiply_s16_DEVROM_66: 16 bit multiplication
 #-----------------------------------------------------------------------
 #
 # Computes C = C + A * B where A,B,C are 16 bits integers.

--- a/Core/interface-dev.json
+++ b/Core/interface-dev.json
@@ -1,5 +1,5 @@
 {
-    "SYS_Multiply_s16_DEVROM_88"      : "0x9e",
+    "SYS_Multiply_s16_DEVROM_66"      : "0x9e",
     "SYS_Divide_s16_DEVROM_80"        : "0xa1",
     "SYS_ScanMemory_DEVROM_50"        : "0xe6",
     "SYS_CopyMemory_DEVROM_80"        : "0xe9",


### PR DESCRIPTION
Sorry.  The previous version seemed to work fine on all tests.  It broke when I tried to change maxticks revealing a confused part of the code.  The test that allows using the fast vrti path needs to account for v6502_adjust, but the tick value that one passes to ENTER should not.  Therefore I cannot use the saved vTmp in line 5239, I need to recompute... 

